### PR TITLE
ASH tiered security scanner integration (Tiers 0–3)

### DIFF
--- a/.ash/ash.yaml
+++ b/.ash/ash.yaml
@@ -21,6 +21,11 @@ global_settings:
       reason: Hook unit-test fixtures, not runtime code.
     - path: claude-dev-toolkit/tests/
       reason: NPM package test fixtures, not shipped code.
+    - path: claude-dev-toolkit/test-reports/
+      reason: >-
+        Generated test-run artifacts (HTML/JSON/MD reports), not source. Their
+        high-entropy test data trips detect-secrets. Candidate for gitignore +
+        git-rm in a follow-up; ignored here meanwhile.
   # Suppressions triaged from the first full ASH scan. These are documented,
   # rule-scoped decisions (not per-finding rubber-stamps): noisy Semgrep audit
   # rules on the CLI installer that are false positives, plus two confirmed test
@@ -58,9 +63,50 @@ global_settings:
     - path: .github/workflows/**
       rule_id: CKV2_GHA_1
       reason: GitHub Actions least-privilege permissions hardening tracked in bd claude-code-0qi.
+      expiration: "2026-09-01"
     - path: .github/workflows/**
       rule_id: CKV_GHA_7
       reason: GitHub Actions hardening tracked in bd claude-code-0qi.
+      expiration: "2026-09-01"
+    # --- detect-secrets: all confirmed false positives (see docs/ash-integration.md
+    # "Findings triage policy"). Scoped as narrowly as practical, never repo-wide. ---
+    - path: "**/*.md"
+      rule_id: SECRET-SECRET-KEYWORD
+      reason: >-
+        Documentation prose and examples that use the words secret/token/
+        password/api_key to describe what the detector catches; no real values.
+    - path: "**/smell_types.py"
+      rule_id: SECRET-SECRET-KEYWORD
+      reason: >-
+        The literal string "secrets" is a smell-kind label / remediation message
+        in code (FIXES["secrets"], SECURITY_SEVERITY), not a credential.
+    - path: claude-dev-toolkit/scripts/publishing/setup-local-registry.sh
+      rule_id: SECRET-SECRET-KEYWORD
+      reason: >-
+        Default admin/admin credential for a throwaway LOCAL verdaccio registry
+        used only in local publish testing; not a real or shipped secret.
+    - path: hooks/README.md
+      rule_id: SECRET-BASIC-AUTH-CREDENTIALS
+      reason: Documentation example of a credential-in-URL pattern (postgres://user:pass@host).
+    - path: claude-dev-toolkit/hooks/README.md
+      rule_id: SECRET-BASIC-AUTH-CREDENTIALS
+      reason: Synced copy of hooks/README.md; same documentation example.
+    - path: hooks/README.md
+      rule_id: SECRET-PRIVATE-KEY
+      reason: Documentation example showing the literal "-----BEGIN PRIVATE KEY-----" pattern the detector matches.
+    - path: claude-dev-toolkit/hooks/README.md
+      rule_id: SECRET-PRIVATE-KEY
+      reason: Synced copy of hooks/README.md; same documentation example.
+    - path: "**/prepush_checks.py"
+      rule_id: SECRET-HEX-HIGH-ENTROPY-STRING
+      reason: >-
+        The 40-char hex string is the pinned ASH git commit SHA
+        (1dca6b3d...), a public revision identifier, not a secret.
+    - path: scripts/setup-github-actions-iam.py
+      rule_id: SECRET-HEX-HIGH-ENTROPY-STRING
+      reason: >-
+        The 40-char hex is GitHub's well-known PUBLIC OIDC root-CA thumbprint
+        (6938fd4d...), a published constant required for the OIDC trust config.
 
 scanners:
   # --- SAST -----------------------------------------------------------------

--- a/.ash/ash.yaml
+++ b/.ash/ash.yaml
@@ -21,6 +21,46 @@ global_settings:
       reason: Hook unit-test fixtures, not runtime code.
     - path: claude-dev-toolkit/tests/
       reason: NPM package test fixtures, not shipped code.
+  # Suppressions triaged from the first full ASH scan. These are documented,
+  # rule-scoped decisions (not per-finding rubber-stamps): noisy Semgrep audit
+  # rules on the CLI installer that are false positives, plus two confirmed test
+  # fixtures / idioms. Genuine findings (npm-publish shell injection, xact.sh
+  # curl|bash) were FIXED, not suppressed. GitHub Actions hardening is tracked
+  # in bd claude-code-0qi.
+  suppressions:
+    - path: claude-dev-toolkit/**
+      rule_id: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+      reason: >-
+        False positive. The toolkit is a local CLI installer that builds paths
+        from trusted config under the user's own ~/.claude; no untrusted remote
+        input reaches path.join/resolve here.
+    - path: claude-dev-toolkit/**
+      rule_id: javascript.lang.security.detect-child-process.detect-child-process
+      reason: >-
+        Accepted. The toolkit is an installer; invoking git/npm via child_process
+        with list args (no shell string interpolation) is its core function.
+    - path: claude-dev-toolkit/**
+      rule_id: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+      reason: False positive. Regexes are built from internal constants, not user input.
+    - path: claude-dev-toolkit/**
+      rule_id: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring
+      reason: False positive. Format arguments are internal, not attacker-controlled.
+    - path: .github/workflows/install-clean-env.yml
+      rule_id: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+      reason: >-
+        Intentional test fixture. This step writes the well-known fake key
+        AKIA...ZZZZZZZ to verify the secret-detection hook fires. Not a real key.
+    - path: scripts/deploy-subagents.sh
+      rule_id: bash.lang.security.ifs-tampering.ifs-tampering
+      reason: >-
+        False positive. IFS=$'\n\t' is the standard bash strict-mode idiom
+        (set -euo pipefail), a hardening measure, not IFS tampering.
+    - path: .github/workflows/**
+      rule_id: CKV2_GHA_1
+      reason: GitHub Actions least-privilege permissions hardening tracked in bd claude-code-0qi.
+    - path: .github/workflows/**
+      rule_id: CKV_GHA_7
+      reason: GitHub Actions hardening tracked in bd claude-code-0qi.
 
 scanners:
   # --- SAST -----------------------------------------------------------------

--- a/.ash/ash.yaml
+++ b/.ash/ash.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/v3.2.6/automated_security_helper/schemas/AshConfig.json
+#
+# ASH (AWS Automated Security Helper) configuration — pinned to v3.2.6.
+# This file is the single source of truth for which scanners ASH runs and at
+# what severity. The tiered git hooks (hooks/scan_router.py) mirror the same
+# scanner-to-filetype applicability mapping; keep the two in sync.
+#
+# ASH runs at Tier 2 (pre-push, `ash --mode precommit`) and Tier 3 (CI,
+# `ash --mode container`) only. It NEVER runs at Tier 0 (PostToolUse) or as
+# an inline per-write gate — those stay sub-300ms Python/secrets-only checks.
+
+project_name: claude-code
+fail_on_findings: true
+
+global_settings:
+  severity_threshold: MEDIUM
+  ignore_paths:
+    - path: tests/
+      reason: Test fixtures and intentionally-insecure sample inputs, not shipped code.
+    - path: hooks/tests/
+      reason: Hook unit-test fixtures, not runtime code.
+    - path: claude-dev-toolkit/tests/
+      reason: NPM package test fixtures, not shipped code.
+
+scanners:
+  # --- SAST -----------------------------------------------------------------
+  bandit:
+    enabled: true
+  semgrep:
+    enabled: true
+  # --- Secrets --------------------------------------------------------------
+  detect-secrets:
+    enabled: true
+  # --- IaC ------------------------------------------------------------------
+  checkov:
+    enabled: true
+  cfn-nag:
+    enabled: true
+  # cdk-nag is DISABLED ON PURPOSE. ASH's README documents a CfnInclude
+  # BootstrapVersion collision on CDK-synthesized templates: cdk-nag re-parses
+  # the synthesized template through CfnInclude, whose BootstrapVersion
+  # parameter handling collides with the CDK bootstrap parameter, producing
+  # spurious failures unrelated to real findings. cfn-nag and checkov remain
+  # enabled and provide CloudFormation coverage. Do not "fix" the collision —
+  # it is an upstream interaction, not a config error in this repo.
+  cdk-nag:
+    enabled: false
+  # --- SCA / dependencies ---------------------------------------------------
+  grype:
+    enabled: true
+  npm-audit:
+    enabled: true

--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -1,0 +1,61 @@
+name: ASH Security (Tier 3)
+
+# Tier 3 of the tiered scanner spine: the un-bypassable, full-tree merge gate.
+# Runs ASH in container mode (all scanners, cross-file analysis) on PRs and
+# pushes to main. Hardened against supply-chain risk: least privilege, no
+# secrets, egress-restricted, and every action + ASH pinned by SHA.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Least privilege at the workflow level; the job re-asserts it.
+permissions:
+  contents: read
+
+concurrency:
+  group: ash-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ash:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # no write, no id-token, no packages
+    steps:
+      - name: Harden runner (egress control)
+        # Start in audit mode to learn ASH's required endpoints, then flip to
+        # egress-policy: block with an allowlist once the audit is reviewed.
+        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        with:
+          egress-policy: audit
+          disable-sudo: false
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Run ASH (container mode, full tree)
+        # ASH pinned to the immutable commit SHA (== tag v3.2.6), consistent
+        # with .ash/ash.yaml, /xsecurity, and the pre-push hook. Container mode
+        # isolates the non-Python scanners in the pinned image. fail_on_findings
+        # is set in .ash/ash.yaml, so a non-zero exit fails the gate.
+        run: |
+          uvx --from \
+            "git+https://github.com/awslabs/automated-security-helper@1dca6b3d10ff274115a159d869bdff8b98624b62" \
+            ash --mode container --source-dir . --output-dir ./.ash/ash_output
+
+      - name: Upload ASH results (SARIF + aggregated JSON + SBOM)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ash-results
+          path: |
+            .ash/ash_output/ash_aggregated_results.json
+            .ash/ash_output/reports/ash.sarif
+            .ash/ash_output/reports/ash.cdx.json
+            .ash/ash_output/reports/ash.summary.md
+          if-no-files-found: warn

--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -38,15 +38,21 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
-      - name: Run ASH (container mode, full tree)
+      - name: Run ASH (local mode, full tree)
         # ASH pinned to the immutable commit SHA (== tag v3.2.6), consistent
-        # with .ash/ash.yaml, /xsecurity, and the pre-push hook. Container mode
-        # isolates the non-Python scanners in the pinned image. fail_on_findings
-        # is set in .ash/ash.yaml, so a non-zero exit fails the gate.
+        # with .ash/ash.yaml, /xsecurity, and the pre-push hook.
+        #
+        # local mode (not container): this repo is not a root-level Python
+        # package, and ASH's container build runs `uv build` on the source,
+        # which fails on a non-Python project. local mode runs the Python
+        # scanners (bandit, semgrep, checkov, detect-secrets) directly; the
+        # non-Python scanners (cfn-nag, grype) report MISSING here and are a
+        # tracked coverage follow-up. fail_on_findings in .ash/ash.yaml makes a
+        # non-zero exit fail the gate.
         run: |
           uvx --from \
             "git+https://github.com/awslabs/automated-security-helper@1dca6b3d10ff274115a159d869bdff8b98624b62" \
-            ash --mode container --source-dir . --output-dir ./.ash/ash_output
+            ash --mode local --source-dir . --output-dir ./.ash/ash_output
 
       - name: Upload ASH results (SARIF + aggregated JSON + SBOM)
         if: always()

--- a/.github/workflows/npm-publish-manual.yml
+++ b/.github/workflows/npm-publish-manual.yml
@@ -32,14 +32,17 @@ jobs:
         working-directory: claude-dev-toolkit
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG: ${{ inputs.tag }}
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          echo "Publishing $PACKAGE_NAME@$PACKAGE_VERSION with tag ${{ inputs.tag }}"
-          npm publish --access public --tag ${{ inputs.tag }}
+          echo "Publishing $PACKAGE_NAME@$PACKAGE_VERSION with tag $TAG"
+          npm publish --access public --tag "$TAG"
 
       - name: Summary
         working-directory: claude-dev-toolkit
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
@@ -47,6 +50,6 @@ jobs:
           echo "## NPM Publish Successful" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Package**: \`$PACKAGE_NAME@$PACKAGE_VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag**: \`${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Install**: \`npm install -g $PACKAGE_NAME@$PACKAGE_VERSION\`" >> $GITHUB_STEP_SUMMARY
           echo "- **NPM**: [View on npmjs.com](https://www.npmjs.com/package/$PACKAGE_NAME)" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ test-results/
 tests/test-results/
 .npmrc
 .beads/
+.quality-gate/
+.ash/ash_output/

--- a/README.md
+++ b/README.md
@@ -269,20 +269,39 @@ Most users authenticate via browser (no API key needed). See [Claude Code docs](
 
 PostToolUse hooks that **block Claude from proceeding** when code violates quality or security thresholds. Claude fixes violations immediately, then continues. Based on the approach described in [Code Quality Gates: Using Claude Code Hooks to Block Code Smells on Every Write](https://www.paulmduvall.com/claude-code-hooks-code-quality-guardrails/).
 
+#### Four-Tier Scanner Model
+
+Scanning is layered for feedback at the speed of typing, escalating to thorough only as the blast radius grows. Each tier is scoped tighter than the last and is **applicability-gated** — a scanner runs only when the change set contains a file type it analyzes, so an irrelevant change (e.g. editing a README) produces no output.
+
+| Tier | Trigger | Budget | Scope | What runs |
+|------|---------|--------|-------|-----------|
+| 0 on-write | PostToolUse Write/Edit | <300ms | the one file written | inline Python smell + secret checks |
+| 1 pre-commit | `git commit` | <5s | staged files | secrets + `checkov` on staged IaC |
+| 2 pre-push | `git push` | <30s | push range | ASH (`precommit` mode) on changed files |
+| 3 CI | PR / push to `main` | minutes | full tree | ASH (`container` mode), all scanners, SARIF + SBOM |
+
+Every tier except CI is **file-scoped**. Cross-file and cross-resource analysis (e.g. a security group defined in one file and referenced in another) is **CI-only by design** — it would blow the smaller budgets. Tier 3 is the only un-bypassable tier. [AWS Automated Security Helper (ASH)](https://github.com/awslabs/automated-security-helper) backs Tiers 2–3; ASH never runs at Tier 0, since nothing in its bundle starts fast enough for a sub-300ms per-write gate. See [docs/ash-integration.md](./docs/ash-integration.md) for the wiring, benchmarks, and supply-chain posture.
+
 #### Quick Setup
 
 ```bash
-# Automated: creates symlinks, merges settings, verifies installation
+# Automated: symlinks the Claude Code hooks (Tier 0) and installs the chained
+# git hooks (Tier 1 pre-commit, Tier 2 pre-push). Idempotent; any pre-existing
+# git hook (e.g. beads) is preserved by chaining, not overwritten.
 bash setup-hooks.sh
+
+# Also merge the PostToolUse/PreToolUse config into ~/.claude/settings.json
+# (opt-in; off by default so your global settings are never edited unless asked)
+bash setup-hooks.sh --wire-settings
 
 # Preview what it will do (no changes made)
 bash setup-hooks.sh --dry-run
 
-# Remove hooks cleanly
+# Remove hooks cleanly (restores any chained hooks)
 bash setup-hooks.sh --uninstall
 ```
 
-Requires Python 3.8+ and jq. Backs up `~/.claude/settings.json` before modifying.
+Requires Python 3.8+. Tier 0 fires only once its config is in `~/.claude/settings.json` — use `--wire-settings` or merge `hooks/settings.example.json` by hand. Tier 3 (CI) needs no install; it ships in `.github/workflows/ash.yml`.
 
 #### What Gets Checked
 
@@ -306,6 +325,7 @@ Language support:
 - **Secrets detection**: AWS keys, GitHub tokens, Stripe keys, OpenAI keys, private keys, credential URLs
 - **Bandit-style checks** (Python): `eval`/`exec`, `shell=True`, pickle, hardcoded passwords, bare `except: pass`
 - **Trojan source**: Unicode bidi overrides and zero-width characters (CVE-2021-42574)
+- **Severity gate**: secrets and HIGH-severity findings **block**; findings below HIGH are reported to Claude without blocking. Secrets are **never suppressible**; honored `# smell|security: ignore[...]` suppressions are logged to `.quality-gate/suppressions.log`.
 
 **Commit Signing** (PreToolUse on Bash via `check-commit-signing.py`):
 - Blocks unsigned `git commit` commands

--- a/claude-dev-toolkit/commands/active/xsecurity.md
+++ b/claude-dev-toolkit/commands/active/xsecurity.md
@@ -1,20 +1,27 @@
 ---
-description: Run security scans with maturity-aware checks and centralized-rules integration
-tags: [security, vulnerabilities, scanning, owasp, secrets, dependencies]
+description: Run security scans via AWS Automated Security Helper (ASH) with maturity-aware thresholds and centralized-rules integration
+tags: [security, vulnerabilities, scanning, ash, secrets, dependencies, sast]
 ---
 
 # Security Analysis
 
-Perform comprehensive security scanning aligned to centralized-rules security principles. No parameters needed for basic usage.
+Run comprehensive security scanning through **AWS Automated Security Helper
+(ASH, pinned v3.2.6)**, aligned to centralized-rules security principles. ASH
+bundles Bandit, Semgrep, detect-secrets, Checkov, cfn-nag, Grype, and npm-audit
+under one CLI and emits unified SARIF/JSON. No parameters needed for basic usage.
+
+This command **shells out to ASH** (deterministic and CI-portable); it does
+**not** depend on the ASH MCP server. The agent-mediated MCP path lives in the
+security-auditor subagent — see the role split below.
 
 ## Usage Examples
 
-**Basic usage (runs all security checks):**
+**Basic usage (full ASH scan, all applicable scanners):**
 ```
 /xsecurity
 ```
 
-**Quick secret scan:**
+**Quick secret scan (standalone, no ASH/uvx required):**
 ```
 /xsecurity secrets
 ```
@@ -42,18 +49,34 @@ Perform comprehensive security scanning aligned to centralized-rules security pr
 
 ## Implementation
 
+ASH is pinned to an **immutable commit SHA** (not the mutable `v3.2.6` tag) so
+runs are reproducible. This is the single recorded pin, kept consistent with
+`.ash/ash.yaml`, `docs/ash-integration.md`, and the pre-push/CI jobs:
+
+```
+ASH_REF=1dca6b3d10ff274115a159d869bdff8b98624b62   # == tag v3.2.6
+ASH="uvx --from git+https://github.com/awslabs/automated-security-helper@${ASH_REF} ash"
+```
+
 If $ARGUMENTS contains "help" or "--help":
-Display this usage information and exit.
+Display this usage information, including the ASH scanner bundle, the three-role
+split (this command = on-demand shell-out; hooks = fast deterministic gate;
+security-auditor subagent = agent-mediated MCP), and exit.
 
-### Step 1: Detect Project Context
+### Step 1: Detect Project Context and ASH Availability
 
-Detect project type and available security tools:
-!ls -la | grep -E "(package.json|requirements.txt|go.mod|Gemfile|pom.xml|composer.json|Cargo.toml)"
-!find . -name ".env*" -not -name ".env.example" | head -5
+Detect project type and confirm ASH can run (uvx present). If ASH is
+unavailable, fall back to the lightweight standalone checks (secrets mode) and
+tell the user how to enable the full scan.
+
+!ls -la | grep -E "(package.json|requirements.txt|go.mod|Gemfile|pom.xml|composer.json|Cargo.toml|\.tf$)" 2>/dev/null
+!command -v uvx >/dev/null 2>&1 && echo "uvx available: full ASH scan enabled" || echo "uvx NOT found: install uv (https://docs.astral.sh/uv/) for full ASH scans; secrets mode still works"
+!find . -name ".env" -not -name ".env.example" -not -path "*/node_modules/*" 2>/dev/null | head -5
 
 ### Step 2: Apply Maturity-Aware Requirements
 
-Per centralized-rules/base/security-principles, requirements vary by maturity:
+Per centralized-rules/base/security-principles, requirements vary by maturity.
+These thresholds govern what **blocks** vs what is **reported**:
 
 | Practice | MVP/POC | Pre-Production | Production |
 |----------|---------|----------------|------------|
@@ -68,83 +91,97 @@ Per centralized-rules/base/security-principles, requirements vary by maturity:
 | Dependency scanning | Optional | Required | Required |
 | Secret scanning | Optional | Required | Required |
 
+**Severity gate by maturity** (applied to ASH findings):
+- **MVP/POC**: block only on CRITICAL and any secret; report everything else.
+- **Pre-Production**: block on HIGH+ and any secret; report MEDIUM/LOW.
+- **Production**: block on MEDIUM+ and any secret; report LOW/INFO.
+
+Secrets always block at every maturity level.
+
 ### Step 3: Execute Based on Mode
 
-**Mode 1: Comprehensive Scan (no arguments or "all")**
+**Mode 1: Comprehensive ASH Scan (no arguments or "all")**
 If $ARGUMENTS is empty or contains "all":
 
-Run complete security analysis covering all centralized-rules principles:
+Run ASH in local mode. `--mode local` uses host scanners via UV tool isolation
+(no container/Docker needed) and honors `.ash/ash.yaml` (severity_threshold
+MEDIUM, cdk-nag disabled). Results land in `.ash/ash_output/`.
 
-1. **Secret Detection**: Scan for exposed credentials and API keys
-!git grep -i -E "(api[_-]?key|secret[_-]?key|password|token|credential|private[_-]?key)" --no-index 2>/dev/null | grep -v -E "(test|spec|mock|example|\.md)" | head -15 || echo "No secrets found in code"
-!find . -name ".env" -not -name ".env.example" -exec echo "WARNING: .env file found: {}" \; 2>/dev/null
+!ASH_REF=1dca6b3d10ff274115a159d869bdff8b98624b62; uvx --from git+https://github.com/awslabs/automated-security-helper@${ASH_REF} ash --mode local 2>&1 | tail -20 || echo "ASH run finished with findings or an error; parsing results below"
 
-2. **Dependency Vulnerabilities**: Check for known CVEs
-!pip-audit 2>/dev/null || npm audit --audit-level=high 2>/dev/null || echo "Install pip-audit or use npm for dependency checks"
+Then parse `.ash/ash_output/ash_aggregated_results.json` and present results.
+Read these keys (schema: AshAggregatedResults at the pinned ref):
 
-3. **Dangerous Code Patterns**: Look for injection risks
-!grep -r -n -E "(eval\(|exec\(|system\(|__import__\(|subprocess\.call\(.*shell=True)" . --include="*.py" 2>/dev/null | head -10
-!grep -r -n -E "(innerHTML|dangerouslySetInnerHTML|document\.write)" . --include="*.js" --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+- **Per-finding detail** — `sarif.runs[].results[]`: each has `ruleId`,
+  `level`, `message.text`, `properties` (scanner name + severity), and
+  `locations[0].physicalLocation.artifactLocation.uri` +
+  `...region.startLine`.
+- **Per-scanner counts** — `scanner_results[<scanner>]` carry a
+  `ScannerSeverityCount` (`critical/high/medium/low/info/suppressed`).
+- **Severity values** are the ASH `Severity` enum:
+  `critical, high, medium, low, info, none, unknown`.
 
-4. **SQL Injection**: Check for string-interpolated queries
-!grep -r -n -E "(f\".*SELECT|f\".*INSERT|f\".*UPDATE|f\".*DELETE|\.format\(.*SELECT)" . --include="*.py" 2>/dev/null | head -10
-!grep -r -n -E "(\`.*SELECT.*\$\{|\`.*INSERT.*\$\{)" . --include="*.js" --include="*.ts" 2>/dev/null | head -10
+!test -f .ash/ash_output/ash_aggregated_results.json && echo "FOUND results" || echo "No aggregated results file — ASH may not have produced output; report the run output above"
 
-5. **Configuration Review**: Check for insecure settings
-!grep -r -n -E "(DEBUG\s*=\s*True|CORS_ALLOW_ALL|verify\s*=\s*False|SSL_VERIFY.*false)" . --include="*.py" --include="*.js" --include="*.ts" --include="*.yml" --include="*.yaml" 2>/dev/null | head -10
+Present a **severity-grouped summary table** (count per severity), then list the
+actionable findings (CRITICAL → HIGH → MEDIUM → LOW) with
+`scanner · ruleId · file:line · message`. Apply the Step 2 severity gate for the
+detected maturity to decide which findings **block** vs are **reported only**.
+Note any suppressed findings (from `.ash/ash.yaml` suppressions) separately.
 
-**Mode 2: Secret Scan Only (argument: "secrets")**
+**Mode 2: Secret Scan Only (argument: "secrets") — standalone, no ASH required**
 If $ARGUMENTS contains "secrets":
 
-Focus on credential exposure per centralized-rules principle #1 (Never Hardcode Secrets):
-!git grep -i -E "(api[_-]?key|secret|password|token|credential|private[_-]?key|aws_access)" --no-index 2>/dev/null | grep -v -E "(test|spec|mock|example|\.md|\.lock)" | head -20
-!git log -p --all -S"api_key" --pickaxe-all 2>/dev/null | grep -E "^\+.*api_key" | head -5 || echo "No secrets in git history"
-!find . -name "*.pem" -o -name "*.key" -o -name "*.p12" 2>/dev/null | head -5
+A fast, dependency-free credential sweep that works even without uvx/ASH. (The
+full ASH scan also runs detect-secrets; this mode is the standalone equivalent.)
+Per centralized-rules principle #1 (Never Hardcode Secrets):
 
-Verify proper secret management:
-- Environment variables used for secrets
-- `.env` files are gitignored
-- No secrets in committed configuration files
+!git grep -i -E "(api[_-]?key|secret|password|token|credential|private[_-]?key|aws_access)" -- ':!*.md' ':!*.lock' 2>/dev/null | grep -v -E "(test|spec|mock|example|placeholder)" | head -20 || echo "No obvious secrets in tracked files"
+!git log -p --all -S"api_key" --pickaxe-all 2>/dev/null | grep -E "^\+.*api_key" | head -5 || echo "No secrets in git history"
+!find . -name "*.pem" -o -name "*.key" -o -name "*.p12" 2>/dev/null | grep -v node_modules | head -5
+
+Verify: environment variables used for secrets; `.env` gitignored; no secrets in
+committed config. Secrets always block regardless of maturity.
 
 **Mode 3: Dependency Check (argument: "deps")**
 If $ARGUMENTS contains "deps":
 
-Per centralized-rules principle #7 (Dependency Management):
-!pip-audit --format=columns 2>/dev/null || npm audit 2>/dev/null || echo "Checking dependencies..."
-!pip list --outdated 2>/dev/null | head -15 || npm outdated 2>/dev/null | head -15
+ASH covers dependencies via Grype (SCA) and npm-audit. Run the full scan and
+filter to dependency findings, or use the native tools directly:
 
-Check:
-- Known CVEs in dependencies
-- Outdated packages with security patches
-- Unused dependencies (reducing exposure)
-- Lock file integrity
+!ASH_REF=1dca6b3d10ff274115a159d869bdff8b98624b62; uvx --from git+https://github.com/awslabs/automated-security-helper@${ASH_REF} ash --mode local 2>&1 | tail -10 || pip-audit 2>/dev/null || npm audit 2>/dev/null || echo "Install uv for ASH, or pip-audit/npm for native dependency checks"
+
+Report known CVEs, outdated packages with security patches, and lock-file
+integrity from `scanner_results.grype` / `scanner_results["npm-audit"]`.
 
 **Mode 4: OWASP Top 10 Review (argument: "owasp")**
 If $ARGUMENTS contains "owasp":
 
-Review code against OWASP Top 10 categories:
+Map ASH's Bandit/Semgrep/Checkov findings to OWASP Top 10 categories, then review
+code for gaps the scanners cannot see:
 
-1. **Injection** (A03): Check parameterized queries, input sanitization
-2. **Broken Auth** (A07): Check password hashing (bcrypt/Argon2), session management
-3. **Sensitive Data Exposure** (A02): Check encryption at rest/transit, error messages
-4. **XSS** (A03): Check output encoding, CSP headers
-5. **CSRF** (A01): Check CSRF tokens, SameSite cookies
-6. **Security Misconfiguration** (A05): Check default credentials, debug mode
-7. **Vulnerable Components** (A06): Check dependency versions
+1. **Injection** (A03): parameterized queries, input sanitization
+2. **Broken Auth** (A07): password hashing (bcrypt/Argon2), session management
+3. **Sensitive Data Exposure** (A02): encryption at rest/transit, error messages
+4. **XSS** (A03): output encoding, CSP headers
+5. **CSRF** (A01): CSRF tokens, SameSite cookies
+6. **Security Misconfiguration** (A05): default credentials, debug mode
+7. **Vulnerable Components** (A06): dependency versions (Grype/npm-audit)
 
 For each category, report: found/not-found/not-applicable with file locations.
 
 **Mode 5: Security Checklist Audit (argument: "checklist")**
 If $ARGUMENTS contains "checklist":
 
-Run the complete centralized-rules secure development checklist:
+Run the complete centralized-rules secure development checklist, using ASH
+findings as evidence where applicable:
 - [ ] No hardcoded secrets or credentials
 - [ ] All user input validated and sanitized
 - [ ] Authentication and authorization implemented
 - [ ] Sensitive data encrypted (at rest and in transit)
 - [ ] HTTPS used for all communication
 - [ ] Error messages don't leak internal details
-- [ ] Dependencies scanned for vulnerabilities
+- [ ] Dependencies scanned for vulnerabilities (ASH: Grype/npm-audit)
 - [ ] Security tests passing
 - [ ] Security events logged (without secrets in logs)
 - [ ] Principle of least privilege applied
@@ -155,16 +192,19 @@ Report pass/fail for each item with file locations for any issues.
 
 ## Security Analysis Results
 
-Categorize findings by severity (per centralized-rules incident response levels):
-- **Critical**: High-risk vulnerability or data breach potential (fix immediately)
-- **High**: Serious vulnerability (fix within days)
-- **Medium**: Important issue (fix in next release)
-- **Low**: Minor issue (fix when convenient)
+Categorize findings by the ASH severity enum (per centralized-rules incident
+response levels):
+- **Critical**: high-risk vulnerability or data-breach potential (fix immediately)
+- **High**: serious vulnerability (fix within days)
+- **Medium**: important issue (fix in next release)
+- **Low / Info**: minor issue (fix when convenient)
 
 Provide:
-1. **Security Status**: Overall posture assessment
-2. **Critical Issues**: Problems requiring immediate attention with file:line locations
-3. **Recommended Actions**: Priority-ordered fix list with specific remediation
-4. **Prevention Tips**: How to avoid similar issues
+1. **Security Status**: overall posture and the severity-grouped summary table
+2. **Blocking Issues**: findings that exceed the maturity severity gate, with
+   `scanner · ruleId · file:line`
+3. **Reported (non-blocking) Issues**: findings below the gate
+4. **Recommended Actions**: priority-ordered fix list with concrete remediation
+5. **Suppressed**: findings excluded via `.ash/ash.yaml`, shown for transparency
 
 Keep output focused on actionable findings with concrete remediation steps.

--- a/claude-dev-toolkit/hooks/check-security.py
+++ b/claude-dev-toolkit/hooks/check-security.py
@@ -15,6 +15,27 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from security_checks import check_security, format_security_violations  # noqa: E402
+from smell_types import blocks_commit, severity_for  # noqa: E402
+
+
+def _format_report(file_path: str, smells: list) -> str:
+    """Build a non-blocking notice for sub-HIGH security findings."""
+    head = f"SECURITY NOTICE (non-blocking) in {file_path}:"
+    rows = [
+        f"  [{severity_for(s.kind).upper()}] {s.name} line {s.line}: {s.detail}"
+        for s in smells
+    ]
+    return "\n".join([head, *rows])
+
+
+def _emit(file_path: str, smells: list) -> None:
+    """Block on secrets/HIGH+; report sub-HIGH findings without blocking."""
+    blocking = [s for s in smells if blocks_commit(s)]
+    if blocking:
+        reason = format_security_violations(file_path, smells)
+        print(json.dumps({"decision": "block", "reason": reason}))
+    else:
+        print(_format_report(file_path, smells), file=sys.stderr)
 
 
 def main() -> None:
@@ -28,8 +49,7 @@ def main() -> None:
         sys.exit(0)
     smells = check_security(file_path)
     if smells:
-        reason = format_security_violations(file_path, smells)
-        print(json.dumps({"decision": "block", "reason": reason}))
+        _emit(file_path, smells)
     sys.exit(0)
 
 

--- a/claude-dev-toolkit/hooks/precommit_checks.py
+++ b/claude-dev-toolkit/hooks/precommit_checks.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Tier 1 pre-commit checks: secrets (always block) + IaC (warn if uvx absent).
+
+Invoked by the chained .git/hooks/pre-commit shim with the staged file list
+(see hooks/git/pre-commit). Applicability-gated and silent when nothing
+applies. Secrets are dependency-free and always block; the checkov IaC scan
+warns but does not block when uvx is unavailable (CI Tier 3 enforces).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from scan_router import check_iac, iac_files, is_text_file  # noqa: E402
+from security_secrets import check_secrets  # noqa: E402
+
+
+def _existing(paths: list[str]) -> list[str]:
+    """Keep only paths that are real files on disk."""
+    return [path for path in paths if os.path.isfile(path)]
+
+
+def _read_lines(path: str) -> list[str]:
+    """Read a file's lines, returning [] on failure."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read().splitlines()
+    except OSError:
+        return []
+
+
+def scan_secrets(files: list[str]) -> bool:
+    """Block (return True) if any staged text file contains a secret."""
+    blocked = False
+    for path in (f for f in files if is_text_file(f)):
+        for smell in check_secrets(_read_lines(path)):
+            sys.stderr.write(f"BLOCKED secret: {path}:{smell.line} {smell.detail}\n")
+            blocked = True
+    return blocked
+
+
+def scan_iac(files: list[str]) -> int:
+    """Run checkov on staged IaC; warn (not block) when uvx is unavailable."""
+    targets = iac_files(files)
+    if not targets:
+        return 0
+    if shutil.which("uvx") is None:
+        sys.stderr.write(
+            "pre-commit: uvx not found; skipping IaC scan (CI Tier 3 enforces)\n"
+        )
+        return 0
+    return check_iac(targets)
+
+
+def main(argv: list[str]) -> int:
+    """Run secrets + IaC checks on the staged file list."""
+    files = _existing(argv)
+    if not files:
+        return 0
+    secret_block = scan_secrets(files)
+    iac_code = scan_iac(files)
+    return 1 if (secret_block or iac_code) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/claude-dev-toolkit/hooks/prepush_checks.py
+++ b/claude-dev-toolkit/hooks/prepush_checks.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Tier 2 pre-push: ASH (precommit mode) scoped to the push range.
+
+Resolves the push range (``git diff @{push}`` with a fallback to the default
+branch on a new branch — never the whole tree), applies the same applicability
+gate as Tier 1, stages the changed files into a temp directory (ASH scans a
+directory, not a file list), and runs ASH's Python-only ``precommit`` mode
+pinned to the recorded commit SHA.
+
+Benchmarked on this repo: ASH precommit has a ~10s warm orchestration floor
+(one-time ~82s cold provisioning) regardless of input size, and pays that floor
+even with zero matching input — so applicability is gated HERE, before ASH is
+invoked at all. Warns (does not block) when uvx is unavailable; the un-bypassable
+CI Tier 3 enforces. Silent when nothing applies.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # noqa: S404 - list-form calls only, no shell=True
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from scan_router import applicable_scanners  # noqa: E402
+
+# Immutable pin (== tag v3.2.6); kept consistent with .ash/ash.yaml & /xsecurity.
+ASH_REF = "1dca6b3d10ff274115a159d869bdff8b98624b62"
+ASH_URL = f"git+https://github.com/awslabs/automated-security-helper@{ASH_REF}"
+# precommit mode runs Python-based scanners only; this is what ASH may run.
+_PRECOMMIT_SCANNERS = frozenset(("bandit", "semgrep", "detect-secrets", "checkov"))
+# Only invoke ASH when a code/IaC scanner applies. detect-secrets alone (e.g. a
+# docs-only push) does NOT trigger the ~10s ASH floor here: secrets are already
+# gated dependency-free at Tier 0/1, and the CI Tier 3 container re-checks them.
+_GATE_SCANNERS = frozenset(("bandit", "semgrep", "checkov"))
+_UVX_MISSING = "pre-push: uvx not found; skipping ASH scan (CI Tier 3 enforces)\n"
+_ASH_TIMEOUT = 120
+
+
+def _run_git(args: list[str]) -> str | None:
+    """Run a git command; return stdout on success, else None."""
+    try:
+        proc = subprocess.run(
+            ["git", *args], capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _default_branch() -> str:
+    """Resolve the remote default branch name, defaulting to 'main'."""
+    ref = _run_git(["symbolic-ref", "refs/remotes/origin/HEAD"])
+    return ref.strip().rsplit("/", 1)[-1] if ref else "main"
+
+
+def _diff_names(rev: str) -> str | None:
+    """Return changed file names against rev (added/copied/modified only)."""
+    return _run_git(["diff", "--name-only", "--diff-filter=ACM", rev])
+
+
+def changed_files() -> list[str]:
+    """Resolve the push-range changed files; never the whole tree."""
+    out = _diff_names("@{push}")
+    if out is None:
+        base = _default_branch()
+        out = _diff_names(f"origin/{base}") or _diff_names(base)
+    if out is None:
+        return []
+    return [f for f in out.splitlines() if f and os.path.isfile(f)]
+
+
+def _stage(files: list[str]) -> str:
+    """Copy changed files into a temp dir, preserving relative paths."""
+    tmp = tempfile.mkdtemp(prefix="ash-prepush-")
+    for rel in files:
+        dest = os.path.join(tmp, rel)
+        os.makedirs(os.path.dirname(dest) or tmp, exist_ok=True)
+        try:
+            shutil.copy2(rel, dest)
+        except OSError:
+            pass
+    return tmp
+
+
+def _run_ash(src: str, scanners: set[str]) -> tuple[int, str]:
+    """Run ASH precommit mode over the staged dir; degrade safe on failure."""
+    cmd = [
+        "uvx", "--from", ASH_URL, "ash", "--mode", "precommit",
+        "--source-dir", src, "--output-dir", os.path.join(src, "_ashout"),
+        "--scanners", ",".join(sorted(scanners)),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_ASH_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0, ""
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _scan(files: list[str], scanners: set[str]) -> int:
+    """Stage, scan, clean up; block (1) on findings, else 0."""
+    src = _stage(files)
+    try:
+        code, output = _run_ash(src, scanners)
+    finally:
+        shutil.rmtree(src, ignore_errors=True)
+    if code != 0 and output.strip():
+        sys.stderr.write(output if output.endswith("\n") else output + "\n")
+    return 1 if code != 0 else 0
+
+
+def main() -> int:
+    """Run the Tier 2 pre-push ASH scan, applicability-gated."""
+    files = changed_files()
+    if not files:
+        return 0
+    applicable = applicable_scanners(files)
+    if not (applicable & _GATE_SCANNERS):
+        return 0
+    if shutil.which("uvx") is None:
+        sys.stderr.write(_UVX_MISSING)
+        return 0
+    return _scan(files, applicable & _PRECOMMIT_SCANNERS)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-dev-toolkit/hooks/scan_router.py
+++ b/claude-dev-toolkit/hooks/scan_router.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Applicability router for the tiered ASH scanner integration.
+
+Single source of truth for "which scanner applies to which file type",
+shared by the tiered git hooks (pre-commit, pre-push) and mirrored by
+``.ash/ash.yaml``. A scanner is applicable only when the change set contains
+a file type it analyzes; an empty or non-applicable change set yields no
+scanners and produces no output.
+
+Also provides the single-file IaC checker (``checkov -f``) used at Tier 1
+(pre-commit). Benchmarked at ~1.5s per file on this repo, which exceeds the
+300ms Tier-0 budget, so the IaC check lives at Tier 1+ and the PostToolUse
+path stays Python/secrets-only. See docs/ash-integration.md.
+
+CloudFormation is detected by content (``Resources`` plus an
+``AWSTemplateFormatVersion`` or an ``AWS::``-style resource type), not by
+extension, so GitHub Actions and Kubernetes YAML are never cfn-nag targets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from functools import lru_cache
+
+# ---------------------------------------------------------------------------
+# File-type classification — the applicability mapping lives here, once.
+# ---------------------------------------------------------------------------
+
+_SEMGREP_EXTS = frozenset((
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rb", ".java", ".php",
+))
+_YAMLISH = frozenset((".yaml", ".yml"))
+_NPM_FILES = frozenset(("package.json", "package-lock.json"))
+# Dependency manifests / lockfiles that Grype (SCA) understands.
+_MANIFESTS = frozenset((
+    "package.json", "package-lock.json", "yarn.lock", "requirements.txt",
+    "pipfile.lock", "poetry.lock", "go.sum", "gemfile.lock", "cargo.lock",
+    "pom.xml",
+))
+# Binary/asset extensions detect-secrets and friends should never read.
+_BINARY_EXTS = frozenset((
+    ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".zip", ".gz", ".tgz", ".ico",
+    ".woff", ".woff2", ".ttf", ".so", ".dylib", ".dll", ".bin", ".jar",
+))
+
+_CFN_TYPE_RE = re.compile(r"""Type:\s*["']?(?:AWS|Custom|Alexa)::""")
+_TOP_RESOURCES_RE = re.compile(r"(?m)^Resources:\s*(?:#.*)?$")
+_TOP_KEY_RE = re.compile(r"(?m)^(?P<key>[A-Za-z][\w-]*):")
+_CHECKOV_TIMEOUT = 20
+
+
+def _ext(path: str) -> str:
+    """Return the lowercased file extension including the dot."""
+    return os.path.splitext(path)[1].lower()
+
+
+@lru_cache(maxsize=256)
+def _read_text(path: str) -> str | None:
+    """Read a file as text, returning None on failure (cached per run)."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def _top_level_keys(text: str) -> set[str]:
+    """Return the set of unindented top-level keys in a YAML-ish document."""
+    return {match.group("key") for match in _TOP_KEY_RE.finditer(text)}
+
+
+def is_text_file(path: str) -> bool:
+    """Return True for files detect-secrets can meaningfully scan."""
+    if _ext(path) in _BINARY_EXTS:
+        return False
+    return _read_text(path) is not None
+
+
+def is_dockerfile(path: str) -> bool:
+    """Return True if the path names a Dockerfile."""
+    base = os.path.basename(path).lower()
+    return base == "dockerfile" or base.endswith((".dockerfile", "-dockerfile"))
+
+
+def _json_is_cfn(text: str) -> bool:
+    """Detect a JSON CloudFormation template by structure."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict) or not isinstance(data.get("Resources"), dict):
+        return False
+    if "AWSTemplateFormatVersion" in data:
+        return True
+    return any(
+        isinstance(res, dict) and str(res.get("Type", "")).startswith(
+            ("AWS::", "Custom::", "Alexa::"))
+        for res in data["Resources"].values()
+    )
+
+
+def _yaml_is_cfn(text: str) -> bool:
+    """Detect a YAML CloudFormation template by content heuristics."""
+    if not _TOP_RESOURCES_RE.search(text):
+        return False
+    return "AWSTemplateFormatVersion" in text or bool(_CFN_TYPE_RE.search(text))
+
+
+def _yaml_text(path: str) -> str | None:
+    """Return the text of a YAML file, or None if not YAML or unreadable."""
+    if _ext(path) not in _YAMLISH:
+        return None
+    return _read_text(path)
+
+
+def is_cfn_template(path: str) -> bool:
+    """Detect a CloudFormation template by content, not by extension.
+
+    GitHub Actions workflows (top-level ``on``/``jobs``) and Kubernetes
+    manifests (top-level ``kind``/``apiVersion``) lack a ``Resources`` block
+    and are deliberately excluded.
+    """
+    if _ext(path) == ".json":
+        text = _read_text(path)
+        return text is not None and _json_is_cfn(text)
+    text = _yaml_text(path)
+    return text is not None and _yaml_is_cfn(text)
+
+
+def is_k8s_manifest(path: str) -> bool:
+    """Detect a Kubernetes manifest by its top-level apiVersion + kind keys."""
+    text = _yaml_text(path)
+    return text is not None and {"apiVersion", "kind"} <= _top_level_keys(text)
+
+
+def is_iac_file(path: str) -> bool:
+    """Return True if checkov should scan this file (Terraform/CFN/k8s/Docker)."""
+    ext = _ext(path)
+    if ext == ".tf" or is_dockerfile(path):
+        return True
+    if ext in _YAMLISH or ext == ".json":
+        return is_cfn_template(path) or is_k8s_manifest(path)
+    return False
+
+
+def _scanners_for_file(path: str) -> set[str]:
+    """Return the scanner names applicable to a single file."""
+    scanners: set[str] = set()
+    ext = _ext(path)
+    base = os.path.basename(path).lower()
+    if is_text_file(path):
+        scanners.add("detect-secrets")
+    if ext == ".py":
+        scanners.add("bandit")
+    if ext in _SEMGREP_EXTS:
+        scanners.add("semgrep")
+    if is_iac_file(path):
+        scanners.add("checkov")
+    if is_cfn_template(path):
+        scanners.add("cfn-nag")
+    if base in _NPM_FILES:
+        scanners.add("npm-audit")
+    if base in _MANIFESTS:
+        scanners.add("grype")
+    return scanners
+
+
+def applicable_scanners(files: list[str]) -> set[str]:
+    """Compute the set of scanners applicable to a change set.
+
+    Args:
+        files: The tier-scoped change set (already filtered to real files).
+
+    Returns:
+        The union of scanners applicable to any file in the change set.
+        Empty when the change set is empty or analyzes nothing.
+    """
+    result: set[str] = set()
+    for path in files:
+        result |= _scanners_for_file(path)
+    return result
+
+
+def iac_files(files: list[str]) -> list[str]:
+    """Filter a change set down to the IaC files checkov should scan."""
+    return [path for path in files if is_iac_file(path)]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 single-file IaC checker (checkov -f)
+# ---------------------------------------------------------------------------
+
+def run_checkov_file(path: str) -> tuple[int, str]:
+    """Run checkov on a single IaC file via uvx; return (returncode, stdout).
+
+    Uses list-form subprocess (never shell=True). Tool/IO failures degrade to
+    a clean (0, "") so a missing checkov never blocks a commit spuriously.
+    """
+    cmd = [
+        "uvx", "--from", "checkov", "checkov",
+        "-f", path, "--compact", "--quiet",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_CHECKOV_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0, ""
+    return proc.returncode, proc.stdout
+
+
+def check_iac(files: list[str]) -> int:
+    """Run checkov on each applicable IaC file; print only real findings.
+
+    Returns a non-zero exit code when checkov reports findings, 0 (silent)
+    when nothing is applicable or everything passes.
+    """
+    targets = iac_files(files)
+    if not targets:
+        return 0
+    failed = False
+    for path in targets:
+        code, output = run_checkov_file(path)
+        if code != 0 and output.strip():
+            sys.stdout.write(output if output.endswith("\n") else output + "\n")
+            failed = True
+    return 1 if failed else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI — internal plumbing for the shell git hooks
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the router CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--files", nargs="*", default=[])
+    parser.add_argument("--print-scanners", action="store_true")
+    parser.add_argument("--check-iac", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _existing_files(paths: list[str]) -> list[str]:
+    """Keep only paths that are real files on disk."""
+    return [path for path in paths if os.path.isfile(path)]
+
+
+def main(argv: list[str]) -> int:
+    """Route a change set to scanner names or run the Tier-1 IaC check."""
+    args = _parse_args(argv)
+    files = _existing_files(args.files)
+    if not files:
+        return 0
+    if args.check_iac:
+        return check_iac(files)
+    if args.print_scanners:
+        scanners = applicable_scanners(files)
+        if scanners:
+            sys.stdout.write(" ".join(sorted(scanners)) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/claude-dev-toolkit/hooks/security_checks.py
+++ b/claude-dev-toolkit/hooks/security_checks.py
@@ -45,7 +45,7 @@ def _run_checks(file_path: str, source: str, config: Config) -> list[Smell]:
     """Run applicable security checks on file contents."""
     lines = source.splitlines()
     smells = _collect_violations(file_path, source, lines, config)
-    return filter_suppressed(smells, lines, "security")
+    return filter_suppressed(smells, lines, "security", file_path)
 
 
 def _collect_violations(

--- a/claude-dev-toolkit/hooks/smell_checks.py
+++ b/claude-dev-toolkit/hooks/smell_checks.py
@@ -221,7 +221,7 @@ def check_file(file_path: str, config: Config | None = None) -> list[Smell]:
     smells.extend(check_file_length(file_path, lines, config))
     smells.extend(check_duplicate_blocks(file_path, lines, config))
     smells.extend(_run_lang_checks(ext, file_path, source))
-    return filter_suppressed(smells, lines, "smell")
+    return filter_suppressed(smells, lines, "smell", file_path)
 
 
 def format_violations(file_path: str, smells: list[Smell]) -> str:

--- a/claude-dev-toolkit/hooks/smell_types.py
+++ b/claude-dev-toolkit/hooks/smell_types.py
@@ -48,6 +48,32 @@ class Smell:
 
 
 # ---------------------------------------------------------------------------
+# Severity model for security findings (drives the on-write severity gate)
+# ---------------------------------------------------------------------------
+# Secrets are special-cased: they ALWAYS block and are never suppressible.
+SECURITY_SEVERITY = {
+    "secrets": "critical",
+    "B102": "high", "B105": "high", "B106": "high", "B602": "high",
+    "trojan_bidi": "high", "trojan_zero_width": "high",
+    "B301": "medium",
+    "B101": "low", "B110": "low",
+}
+_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+
+
+def severity_for(kind: str) -> str:
+    """Return the severity label for a security finding kind (default medium)."""
+    return SECURITY_SEVERITY.get(kind, "medium")
+
+
+def blocks_commit(smell: Smell) -> bool:
+    """Secrets always block; other security findings block only at HIGH+."""
+    if smell.kind == "secrets":
+        return True
+    return _SEVERITY_RANK.get(severity_for(smell.kind), 2) >= _SEVERITY_RANK["high"]
+
+
+# ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 

--- a/claude-dev-toolkit/hooks/suppression.py
+++ b/claude-dev-toolkit/hooks/suppression.py
@@ -10,8 +10,10 @@ No wildcards supported -- explicit check names required.
 
 from __future__ import annotations
 
+import os
 import re
 import sys
+from pathlib import Path
 
 from smell_types import Smell
 
@@ -68,15 +70,52 @@ def _warn_excessive(count: int, total_lines: int) -> None:
         )
 
 
+def _repo_root(start: str) -> str:
+    """Walk up from start to the nearest .git ancestor; fall back to start."""
+    current = os.path.abspath(start)
+    while True:
+        if os.path.isdir(os.path.join(current, ".git")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return os.path.abspath(start)
+        current = parent
+
+
+def _log_suppressions(
+    smells: list[Smell], namespace: str, file_path: str,
+) -> None:
+    """Append honored (non-secret) suppressions to the audit log, best-effort."""
+    root = _repo_root(os.path.dirname(os.path.abspath(file_path)))
+    log_path = Path(root) / ".quality-gate" / "suppressions.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as handle:
+            for smell in smells:
+                handle.write(f"{file_path}:{smell.line} {namespace}:{smell.kind}\n")
+    except OSError:
+        pass
+
+
 def filter_suppressed(
     smells: list[Smell], lines: list[str], namespace: str,
+    file_path: str | None = None,
 ) -> list[Smell]:
-    """Remove smells covered by inline suppression comments."""
+    """Remove smells covered by inline suppression comments.
+
+    Secrets are never suppressible. Every honored suppression is appended to
+    the audit log (.quality-gate/suppressions.log) when file_path is given.
+    """
     suppression_map = _build_suppression_map(lines)
     _warn_excessive(len(suppression_map), len(lines))
-    result: list[Smell] = []
+    kept: list[Smell] = []
+    honored: list[Smell] = []
     for smell in smells:
         active = suppression_map.get(smell.line, {})
-        if not _is_suppressed(smell, namespace, active):
-            result.append(smell)
-    return result
+        if smell.kind != "secrets" and _is_suppressed(smell, namespace, active):
+            honored.append(smell)
+        else:
+            kept.append(smell)
+    if honored and file_path:
+        _log_suppressions(honored, namespace, file_path)
+    return kept

--- a/docs/ash-integration.md
+++ b/docs/ash-integration.md
@@ -1,0 +1,80 @@
+# ASH Tiered Security Integration
+
+AWS Automated Security Helper ([ASH](https://github.com/awslabs/automated-security-helper),
+pinned **v3.2.6**) is the scanner orchestration layer for this repo. It bundles
+Bandit, Semgrep, detect-secrets, Checkov, cfn-nag, Grype, and npm-audit under one
+CLI with UV tool isolation and unified SARIF/JSON output.
+
+ASH is wired across **four latency tiers**, each scoped tighter and budgeted
+faster than the last. The point is feedback at the speed of typing, escalating to
+thorough only as the blast radius grows.
+
+| Tier | Trigger | Budget | Scope | What runs |
+|------|---------|--------|-------|-----------|
+| 0 on-write | PostToolUse Write/Edit | <300ms | the one file just written | inline Python hooks (smells + secrets) only |
+| 1 pre-commit | `git commit` | <5s | staged files | single-file `checkov` on staged IaC, secrets on staged |
+| 2 pre-push | `git push` | <30s | push range | `ash --mode precommit` on changed files |
+| 3 CI | PR / push to main | minutes | full tree | `ash --mode container`, all scanners, SARIF upload |
+
+Each tier is a **superset** of the prior tier's coverage. Tiers 0–2 are
+file-scoped; cross-file and cross-resource analysis (e.g. a security group defined
+in one `.tf` and referenced in another) is **Tier 3's job only**, by design — it
+blows the smaller budgets. Tier 3 is the only un-bypassable tier.
+
+## Applicability gating
+
+Tiers decide *how fast*; applicability decides *whether at all*. The change set is
+computed once per invocation, then each scanner runs **only if** the change set
+contains a file type it analyzes. The mapping lives in exactly one place,
+[`hooks/scan_router.py`](../hooks/scan_router.py), and is mirrored by
+[`.ash/ash.yaml`](../.ash/ash.yaml):
+
+| Scanner | Runs only if change set contains |
+|---------|----------------------------------|
+| Bandit | `.py` |
+| Semgrep | a configured language (`.py`/`.js`/`.ts`/`.go`/…) |
+| Checkov | `.tf` / CloudFormation / Kubernetes manifest / Dockerfile |
+| cfn-nag | a CloudFormation template (**detected by content**) |
+| detect-secrets | any text file |
+| npm-audit | `package.json` / `package-lock.json` |
+| Grype (SCA) | a dependency manifest / lockfile |
+
+CloudFormation is detected **by content, not extension**: a `.yaml` file is a
+cfn-nag target only if it has a top-level `Resources` block plus an
+`AWSTemplateFormatVersion` or an `AWS::`-style resource `Type`. GitHub Actions
+workflows and Kubernetes manifests are YAML too and are deliberately excluded.
+
+An empty or non-applicable change set exits **0, silently** — no "nothing to scan"
+banner. The only success line printed is at Tier 3 CI; Tiers 0–2 stay silent on
+success.
+
+## cdk-nag is disabled
+
+cdk-nag is disabled in [`.ash/ash.yaml`](../.ash/ash.yaml). ASH's README documents
+a `CfnInclude` `BootstrapVersion` collision on CDK-synthesized templates that
+produces spurious failures. **cfn-nag and checkov remain enabled** for
+CloudFormation coverage. This is an upstream interaction, not a config error — do
+not attempt to "fix" the collision.
+
+## Benchmark numbers
+
+Measured on this repo (macOS, Apple Silicon, Python 3.14, scanners via `uvx`).
+The numbers — not the table above — decide tier placement.
+
+| Measurement | Result | Decision |
+|-------------|--------|----------|
+| `checkov -f <one .tf>` (steady-state, via `uvx`) | **~1.55s** (1.52 / 1.55 / 1.61s) | **>300ms → IaC check lives at Tier 1**, not Tier 0. PostToolUse stays Python/secrets-only. Well under the 5s Tier-1 budget. |
+| pure `python3` startup floor | 0.01s | inline Python hooks have ample headroom under 300ms |
+| `ash --mode precommit` (1–2 file change) | *pending* | measured when Tier 2 pre-push is wired (T4) |
+| `ash --mode container` (full tree) | *pending* | measured by the first Tier 3 CI run (T4); needs a container runtime, which CI provides |
+| ASH per-scanner zero-input startup | *pending* | decides whether applicability gating must happen at the wrapper before invoking ASH (T4) |
+
+**Why checkov is Tier 1, not Tier 0:** the single-file run is ~1.5s, roughly 5×
+the 300ms on-write budget. Per the integration's own escape clause, the IaC check
+drops to Tier 1 (pre-commit) where the budget is 5s, and the PostToolUse on-write
+gate stays the existing inline Python smell + secret checks. Nothing in the ASH
+bundle starts fast enough for a sub-300ms per-write gate, which is why ASH never
+runs at Tier 0.
+
+The pending ASH-mode numbers are captured when Tiers 2–3 are wired; the container
+figure is authoritative from CI, where Docker is present by default.

--- a/docs/ash-integration.md
+++ b/docs/ash-integration.md
@@ -100,6 +100,39 @@ precommit` on the changed files":
 
 The container figure is authoritative from CI, where Docker is present by default.
 
+## Findings triage policy
+
+Suppressions are a system with documented reasons, not silent ignores. Every
+finding ASH reports is resolved in exactly one of three ways, all visible in
+version control and reviewed in the PR that introduces them:
+
+1. **FIXED** — the finding is real and corrected in code (e.g. the GitHub
+   Actions script injection in `npm-publish-manual.yml` and the `curl | bash`
+   in `scripts/xact.sh` were fixed, not suppressed).
+2. **SUPPRESSED with a reason** — a confirmed false positive or an accepted,
+   explained risk. Each entry in `.ash/ash.yaml` `global_settings.suppressions`
+   carries:
+   - a **`rule_id`** and a **`path`** scoped as narrowly as practical (never a
+     blanket repo-wide "ignore everything"),
+   - a **`reason`** stating *why* it is not actionable (e.g. "this 40-char hex
+     is the pinned ASH commit SHA, not a secret"; "documentation example of a
+     credential pattern").
+3. **TRACKED** — real but out-of-scope-to-fix-now work is suppressed with a
+   reason that **references a Beads task** and an **`expiration`** date that
+   forces re-review (e.g. the GitHub Actions hardening tracked in
+   `claude-code-0qi`, expiring `2026-09-01`).
+
+Rules of thumb: prefer FIX over SUPPRESS; scope suppressions to the narrowest
+`path` + `rule_id` that covers the false positive; give accepted-risk and
+tracked suppressions an `expiration` so they cannot rot; secrets findings are
+suppressed only after confirming each is a non-secret (the inline Tier 0/1
+hooks keep real secrets non-suppressible regardless).
+
+Note on local vs CI for secrets: ASH's `detect-secrets` plugin runs in CI but
+no-ops in local `--mode local` on some machines (the tool runs in an isolated
+`uvx` environment). Treat **CI as the authoritative validator for
+detect-secrets**; the suppressions above were triaged from the CI artifact.
+
 ## Install & activation
 
 One entry point wires the local spine: `bash scripts/setup-hooks.sh`. It is

--- a/docs/ash-integration.md
+++ b/docs/ash-integration.md
@@ -65,9 +65,11 @@ The numbers — not the table above — decide tier placement.
 |-------------|--------|----------|
 | `checkov -f <one .tf>` (steady-state, via `uvx`) | **~1.55s** (1.52 / 1.55 / 1.61s) | **>300ms → IaC check lives at Tier 1**, not Tier 0. PostToolUse stays Python/secrets-only. Well under the 5s Tier-1 budget. |
 | pure `python3` startup floor | 0.01s | inline Python hooks have ample headroom under 300ms |
-| `ash --mode precommit` (1–2 file change) | *pending* | measured when Tier 2 pre-push is wired (T4) |
-| `ash --mode container` (full tree) | *pending* | measured by the first Tier 3 CI run (T4); needs a container runtime, which CI provides |
-| ASH per-scanner zero-input startup | *pending* | decides whether applicability gating must happen at the wrapper before invoking ASH (T4) |
+| `ash --mode precommit`, **cold** (first run, tool provisioning) | **82.1s** | one-time cost when ASH's tool copies are first built; not paid per-push |
+| `ash --mode precommit`, **warm** (1-file change) | **9.9s** | under the 30s Tier-2 budget, but a ~10s fixed floor |
+| `ash --mode precommit`, **warm** (zero matching input) | **9.7s** | ASH pays the floor even with nothing to scan → **applicability MUST be gated at the wrapper** (don't invoke ASH unless a code/IaC scanner applies). Confirms applicability rule 6. |
+| `ash --mode precommit --scanners checkov` (warm) | **9.8s** | scoping to one scanner does **not** reduce the floor — the ~10s is ASH orchestration, not scanner count |
+| `ash --mode container` (full tree) | *CI-only* | needs a container runtime; measured by the first Tier 3 CI run (Docker is present on the runner) |
 
 **Why checkov is Tier 1, not Tier 0:** the single-file run is ~1.5s, roughly 5×
 the 300ms on-write budget. Per the integration's own escape clause, the IaC check
@@ -76,5 +78,44 @@ gate stays the existing inline Python smell + secret checks. Nothing in the ASH
 bundle starts fast enough for a sub-300ms per-write gate, which is why ASH never
 runs at Tier 0.
 
-The pending ASH-mode numbers are captured when Tiers 2–3 are wired; the container
-figure is authoritative from CI, where Docker is present by default.
+### Tier 2 (pre-push) design notes — what the benchmark forced
+
+Two facts from the numbers changed the wiring from the naive "run `ash --mode
+precommit` on the changed files":
+
+1. **`precommit` is a *speed preset*, not a git filter.** In ASH v3.2.6,
+   `--mode precommit` means "Python-based scanners only, simplified output" — it
+   scans the whole `--source-dir`; there is **no per-file flag**. To keep Tier 2
+   file-scoped, the pre-push hook stages the push-range files into a temp dir and
+   runs ASH with `--source-dir` pointed at it. Cross-file analysis is therefore
+   **not** done at Tier 2 by design — that is Tier 3's job.
+2. **ASH pays a ~10s floor even for zero input.** So `hooks/prepush_checks.py`
+   gates *before* invoking ASH: it computes the push range
+   (`git diff --name-only @{push}`, falling back to the default branch on a new
+   branch — never the whole tree), and runs ASH only when a **code/IaC** scanner
+   (`bandit`/`semgrep`/`checkov`) applies. A docs-only push matches only
+   `detect-secrets`, which is already gated dependency-free at Tiers 0–1 and
+   re-checked by the CI container — so it does **not** pay the ASH floor and the
+   pre-push exits silently.
+
+The container figure is authoritative from CI, where Docker is present by default.
+
+## Install & activation
+
+One entry point wires the local spine: `bash scripts/setup-hooks.sh`. It is
+idempotent and:
+
+- symlinks the Claude Code hooks into `~/.claude/hooks/`,
+- installs **chained** git hooks (Tier 1 `pre-commit`, Tier 2 `pre-push`) via
+  `scripts/install-git-hooks.sh`, preserving any pre-existing hook (e.g. the
+  beads `pre-commit`) by chaining it — no `core.hooksPath` override.
+
+**Tier 0 activation is opt-in.** The PostToolUse hooks fire only once their
+config is present in `~/.claude/settings.json`. By default `setup-hooks.sh` does
+**not** edit your global settings; pass `--wire-settings` to merge
+`hooks/settings.example.json` in idempotently (additive — existing hooks are
+preserved), or merge it by hand. Tier 3 (CI) needs no install: it ships in
+`.github/workflows/ash.yml` and runs on PRs and pushes to `main`.
+
+Uninstall with `bash scripts/setup-hooks.sh --uninstall` (restores any chained
+hooks).

--- a/hooks/check-security.py
+++ b/hooks/check-security.py
@@ -15,6 +15,27 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from security_checks import check_security, format_security_violations  # noqa: E402
+from smell_types import blocks_commit, severity_for  # noqa: E402
+
+
+def _format_report(file_path: str, smells: list) -> str:
+    """Build a non-blocking notice for sub-HIGH security findings."""
+    head = f"SECURITY NOTICE (non-blocking) in {file_path}:"
+    rows = [
+        f"  [{severity_for(s.kind).upper()}] {s.name} line {s.line}: {s.detail}"
+        for s in smells
+    ]
+    return "\n".join([head, *rows])
+
+
+def _emit(file_path: str, smells: list) -> None:
+    """Block on secrets/HIGH+; report sub-HIGH findings without blocking."""
+    blocking = [s for s in smells if blocks_commit(s)]
+    if blocking:
+        reason = format_security_violations(file_path, smells)
+        print(json.dumps({"decision": "block", "reason": reason}))
+    else:
+        print(_format_report(file_path, smells), file=sys.stderr)
 
 
 def main() -> None:
@@ -28,8 +49,7 @@ def main() -> None:
         sys.exit(0)
     smells = check_security(file_path)
     if smells:
-        reason = format_security_violations(file_path, smells)
-        print(json.dumps({"decision": "block", "reason": reason}))
+        _emit(file_path, smells)
     sys.exit(0)
 
 

--- a/hooks/git/pre-commit
+++ b/hooks/git/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Tier 1 pre-commit logic (tracked). Runs secrets (always block) + checkov on
+# staged IaC (warn-not-block if uvx absent). Applicability-gated and silent
+# when nothing applies. Installed as a chained shim by
+# scripts/install-git-hooks.sh, which also preserves any pre-existing hook
+# (e.g. the beads pre-commit) by chaining it after this one.
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+[ -z "$STAGED" ] && exit 0
+# shellcheck disable=SC2086
+exec python3 "$REPO/hooks/precommit_checks.py" $STAGED

--- a/hooks/git/pre-push
+++ b/hooks/git/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Tier 2 pre-push logic (tracked). Runs ASH (precommit mode, Python-only
+# scanners) scoped to the push range, applicability-gated and silent when
+# nothing applies. Warns (does not block) when uvx is absent; the un-bypassable
+# CI Tier 3 enforces. Installed as a chained shim by
+# scripts/install-git-hooks.sh (which also chains any pre-existing pre-push).
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+exec python3 "$REPO/hooks/prepush_checks.py"

--- a/hooks/git/shim.template
+++ b/hooks/git/shim.template
@@ -1,0 +1,17 @@
+#!/bin/sh
+# >>> claude-code-managed chained hook (logic: hooks/git/HOOKNAME) — do not edit
+# Installed by scripts/install-git-hooks.sh. Runs the tracked hook logic, then
+# chains any pre-existing hook preserved at HOOKNAME.chained (e.g. beads).
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+HOOK_DIR=$(dirname "$0")
+TMP=$(mktemp 2>/dev/null) || TMP="${TMPDIR:-/tmp}/cc-hook.$$"
+cat > "$TMP"
+"$REPO/hooks/git/HOOKNAME" "$@" < "$TMP"
+rc=$?
+if [ "$rc" -ne 0 ]; then rm -f "$TMP"; exit "$rc"; fi
+if [ -x "$HOOK_DIR/HOOKNAME.chained" ]; then
+  "$HOOK_DIR/HOOKNAME.chained" "$@" < "$TMP"
+  rc=$?
+fi
+rm -f "$TMP"
+exit "$rc"

--- a/hooks/precommit_checks.py
+++ b/hooks/precommit_checks.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Tier 1 pre-commit checks: secrets (always block) + IaC (warn if uvx absent).
+
+Invoked by the chained .git/hooks/pre-commit shim with the staged file list
+(see hooks/git/pre-commit). Applicability-gated and silent when nothing
+applies. Secrets are dependency-free and always block; the checkov IaC scan
+warns but does not block when uvx is unavailable (CI Tier 3 enforces).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from scan_router import check_iac, iac_files, is_text_file  # noqa: E402
+from security_secrets import check_secrets  # noqa: E402
+
+
+def _existing(paths: list[str]) -> list[str]:
+    """Keep only paths that are real files on disk."""
+    return [path for path in paths if os.path.isfile(path)]
+
+
+def _read_lines(path: str) -> list[str]:
+    """Read a file's lines, returning [] on failure."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read().splitlines()
+    except OSError:
+        return []
+
+
+def scan_secrets(files: list[str]) -> bool:
+    """Block (return True) if any staged text file contains a secret."""
+    blocked = False
+    for path in (f for f in files if is_text_file(f)):
+        for smell in check_secrets(_read_lines(path)):
+            sys.stderr.write(f"BLOCKED secret: {path}:{smell.line} {smell.detail}\n")
+            blocked = True
+    return blocked
+
+
+def scan_iac(files: list[str]) -> int:
+    """Run checkov on staged IaC; warn (not block) when uvx is unavailable."""
+    targets = iac_files(files)
+    if not targets:
+        return 0
+    if shutil.which("uvx") is None:
+        sys.stderr.write(
+            "pre-commit: uvx not found; skipping IaC scan (CI Tier 3 enforces)\n"
+        )
+        return 0
+    return check_iac(targets)
+
+
+def main(argv: list[str]) -> int:
+    """Run secrets + IaC checks on the staged file list."""
+    files = _existing(argv)
+    if not files:
+        return 0
+    secret_block = scan_secrets(files)
+    iac_code = scan_iac(files)
+    return 1 if (secret_block or iac_code) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/hooks/prepush_checks.py
+++ b/hooks/prepush_checks.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Tier 2 pre-push: ASH (precommit mode) scoped to the push range.
+
+Resolves the push range (``git diff @{push}`` with a fallback to the default
+branch on a new branch — never the whole tree), applies the same applicability
+gate as Tier 1, stages the changed files into a temp directory (ASH scans a
+directory, not a file list), and runs ASH's Python-only ``precommit`` mode
+pinned to the recorded commit SHA.
+
+Benchmarked on this repo: ASH precommit has a ~10s warm orchestration floor
+(one-time ~82s cold provisioning) regardless of input size, and pays that floor
+even with zero matching input — so applicability is gated HERE, before ASH is
+invoked at all. Warns (does not block) when uvx is unavailable; the un-bypassable
+CI Tier 3 enforces. Silent when nothing applies.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # noqa: S404 - list-form calls only, no shell=True
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from scan_router import applicable_scanners  # noqa: E402
+
+# Immutable pin (== tag v3.2.6); kept consistent with .ash/ash.yaml & /xsecurity.
+ASH_REF = "1dca6b3d10ff274115a159d869bdff8b98624b62"
+ASH_URL = f"git+https://github.com/awslabs/automated-security-helper@{ASH_REF}"
+# precommit mode runs Python-based scanners only; this is what ASH may run.
+_PRECOMMIT_SCANNERS = frozenset(("bandit", "semgrep", "detect-secrets", "checkov"))
+# Only invoke ASH when a code/IaC scanner applies. detect-secrets alone (e.g. a
+# docs-only push) does NOT trigger the ~10s ASH floor here: secrets are already
+# gated dependency-free at Tier 0/1, and the CI Tier 3 container re-checks them.
+_GATE_SCANNERS = frozenset(("bandit", "semgrep", "checkov"))
+_UVX_MISSING = "pre-push: uvx not found; skipping ASH scan (CI Tier 3 enforces)\n"
+_ASH_TIMEOUT = 120
+
+
+def _run_git(args: list[str]) -> str | None:
+    """Run a git command; return stdout on success, else None."""
+    try:
+        proc = subprocess.run(
+            ["git", *args], capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _default_branch() -> str:
+    """Resolve the remote default branch name, defaulting to 'main'."""
+    ref = _run_git(["symbolic-ref", "refs/remotes/origin/HEAD"])
+    return ref.strip().rsplit("/", 1)[-1] if ref else "main"
+
+
+def _diff_names(rev: str) -> str | None:
+    """Return changed file names against rev (added/copied/modified only)."""
+    return _run_git(["diff", "--name-only", "--diff-filter=ACM", rev])
+
+
+def changed_files() -> list[str]:
+    """Resolve the push-range changed files; never the whole tree."""
+    out = _diff_names("@{push}")
+    if out is None:
+        base = _default_branch()
+        out = _diff_names(f"origin/{base}") or _diff_names(base)
+    if out is None:
+        return []
+    return [f for f in out.splitlines() if f and os.path.isfile(f)]
+
+
+def _stage(files: list[str]) -> str:
+    """Copy changed files into a temp dir, preserving relative paths."""
+    tmp = tempfile.mkdtemp(prefix="ash-prepush-")
+    for rel in files:
+        dest = os.path.join(tmp, rel)
+        os.makedirs(os.path.dirname(dest) or tmp, exist_ok=True)
+        try:
+            shutil.copy2(rel, dest)
+        except OSError:
+            pass
+    return tmp
+
+
+def _run_ash(src: str, scanners: set[str]) -> tuple[int, str]:
+    """Run ASH precommit mode over the staged dir; degrade safe on failure."""
+    cmd = [
+        "uvx", "--from", ASH_URL, "ash", "--mode", "precommit",
+        "--source-dir", src, "--output-dir", os.path.join(src, "_ashout"),
+        "--scanners", ",".join(sorted(scanners)),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_ASH_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0, ""
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _scan(files: list[str], scanners: set[str]) -> int:
+    """Stage, scan, clean up; block (1) on findings, else 0."""
+    src = _stage(files)
+    try:
+        code, output = _run_ash(src, scanners)
+    finally:
+        shutil.rmtree(src, ignore_errors=True)
+    if code != 0 and output.strip():
+        sys.stderr.write(output if output.endswith("\n") else output + "\n")
+    return 1 if code != 0 else 0
+
+
+def main() -> int:
+    """Run the Tier 2 pre-push ASH scan, applicability-gated."""
+    files = changed_files()
+    if not files:
+        return 0
+    applicable = applicable_scanners(files)
+    if not (applicable & _GATE_SCANNERS):
+        return 0
+    if shutil.which("uvx") is None:
+        sys.stderr.write(_UVX_MISSING)
+        return 0
+    return _scan(files, applicable & _PRECOMMIT_SCANNERS)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/scan_router.py
+++ b/hooks/scan_router.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Applicability router for the tiered ASH scanner integration.
+
+Single source of truth for "which scanner applies to which file type",
+shared by the tiered git hooks (pre-commit, pre-push) and mirrored by
+``.ash/ash.yaml``. A scanner is applicable only when the change set contains
+a file type it analyzes; an empty or non-applicable change set yields no
+scanners and produces no output.
+
+Also provides the single-file IaC checker (``checkov -f``) used at Tier 1
+(pre-commit). Benchmarked at ~1.5s per file on this repo, which exceeds the
+300ms Tier-0 budget, so the IaC check lives at Tier 1+ and the PostToolUse
+path stays Python/secrets-only. See docs/ash-integration.md.
+
+CloudFormation is detected by content (``Resources`` plus an
+``AWSTemplateFormatVersion`` or an ``AWS::``-style resource type), not by
+extension, so GitHub Actions and Kubernetes YAML are never cfn-nag targets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from functools import lru_cache
+
+# ---------------------------------------------------------------------------
+# File-type classification — the applicability mapping lives here, once.
+# ---------------------------------------------------------------------------
+
+_SEMGREP_EXTS = frozenset((
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rb", ".java", ".php",
+))
+_YAMLISH = frozenset((".yaml", ".yml"))
+_NPM_FILES = frozenset(("package.json", "package-lock.json"))
+# Dependency manifests / lockfiles that Grype (SCA) understands.
+_MANIFESTS = frozenset((
+    "package.json", "package-lock.json", "yarn.lock", "requirements.txt",
+    "pipfile.lock", "poetry.lock", "go.sum", "gemfile.lock", "cargo.lock",
+    "pom.xml",
+))
+# Binary/asset extensions detect-secrets and friends should never read.
+_BINARY_EXTS = frozenset((
+    ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".zip", ".gz", ".tgz", ".ico",
+    ".woff", ".woff2", ".ttf", ".so", ".dylib", ".dll", ".bin", ".jar",
+))
+
+_CFN_TYPE_RE = re.compile(r"""Type:\s*["']?(?:AWS|Custom|Alexa)::""")
+_TOP_RESOURCES_RE = re.compile(r"(?m)^Resources:\s*(?:#.*)?$")
+_TOP_KEY_RE = re.compile(r"(?m)^(?P<key>[A-Za-z][\w-]*):")
+_CHECKOV_TIMEOUT = 20
+
+
+def _ext(path: str) -> str:
+    """Return the lowercased file extension including the dot."""
+    return os.path.splitext(path)[1].lower()
+
+
+@lru_cache(maxsize=256)
+def _read_text(path: str) -> str | None:
+    """Read a file as text, returning None on failure (cached per run)."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def _top_level_keys(text: str) -> set[str]:
+    """Return the set of unindented top-level keys in a YAML-ish document."""
+    return {match.group("key") for match in _TOP_KEY_RE.finditer(text)}
+
+
+def is_text_file(path: str) -> bool:
+    """Return True for files detect-secrets can meaningfully scan."""
+    if _ext(path) in _BINARY_EXTS:
+        return False
+    return _read_text(path) is not None
+
+
+def is_dockerfile(path: str) -> bool:
+    """Return True if the path names a Dockerfile."""
+    base = os.path.basename(path).lower()
+    return base == "dockerfile" or base.endswith((".dockerfile", "-dockerfile"))
+
+
+def _json_is_cfn(text: str) -> bool:
+    """Detect a JSON CloudFormation template by structure."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict) or not isinstance(data.get("Resources"), dict):
+        return False
+    if "AWSTemplateFormatVersion" in data:
+        return True
+    return any(
+        isinstance(res, dict) and str(res.get("Type", "")).startswith(
+            ("AWS::", "Custom::", "Alexa::"))
+        for res in data["Resources"].values()
+    )
+
+
+def _yaml_is_cfn(text: str) -> bool:
+    """Detect a YAML CloudFormation template by content heuristics."""
+    if not _TOP_RESOURCES_RE.search(text):
+        return False
+    return "AWSTemplateFormatVersion" in text or bool(_CFN_TYPE_RE.search(text))
+
+
+def _yaml_text(path: str) -> str | None:
+    """Return the text of a YAML file, or None if not YAML or unreadable."""
+    if _ext(path) not in _YAMLISH:
+        return None
+    return _read_text(path)
+
+
+def is_cfn_template(path: str) -> bool:
+    """Detect a CloudFormation template by content, not by extension.
+
+    GitHub Actions workflows (top-level ``on``/``jobs``) and Kubernetes
+    manifests (top-level ``kind``/``apiVersion``) lack a ``Resources`` block
+    and are deliberately excluded.
+    """
+    if _ext(path) == ".json":
+        text = _read_text(path)
+        return text is not None and _json_is_cfn(text)
+    text = _yaml_text(path)
+    return text is not None and _yaml_is_cfn(text)
+
+
+def is_k8s_manifest(path: str) -> bool:
+    """Detect a Kubernetes manifest by its top-level apiVersion + kind keys."""
+    text = _yaml_text(path)
+    return text is not None and {"apiVersion", "kind"} <= _top_level_keys(text)
+
+
+def is_iac_file(path: str) -> bool:
+    """Return True if checkov should scan this file (Terraform/CFN/k8s/Docker)."""
+    ext = _ext(path)
+    if ext == ".tf" or is_dockerfile(path):
+        return True
+    if ext in _YAMLISH or ext == ".json":
+        return is_cfn_template(path) or is_k8s_manifest(path)
+    return False
+
+
+def _scanners_for_file(path: str) -> set[str]:
+    """Return the scanner names applicable to a single file."""
+    scanners: set[str] = set()
+    ext = _ext(path)
+    base = os.path.basename(path).lower()
+    if is_text_file(path):
+        scanners.add("detect-secrets")
+    if ext == ".py":
+        scanners.add("bandit")
+    if ext in _SEMGREP_EXTS:
+        scanners.add("semgrep")
+    if is_iac_file(path):
+        scanners.add("checkov")
+    if is_cfn_template(path):
+        scanners.add("cfn-nag")
+    if base in _NPM_FILES:
+        scanners.add("npm-audit")
+    if base in _MANIFESTS:
+        scanners.add("grype")
+    return scanners
+
+
+def applicable_scanners(files: list[str]) -> set[str]:
+    """Compute the set of scanners applicable to a change set.
+
+    Args:
+        files: The tier-scoped change set (already filtered to real files).
+
+    Returns:
+        The union of scanners applicable to any file in the change set.
+        Empty when the change set is empty or analyzes nothing.
+    """
+    result: set[str] = set()
+    for path in files:
+        result |= _scanners_for_file(path)
+    return result
+
+
+def iac_files(files: list[str]) -> list[str]:
+    """Filter a change set down to the IaC files checkov should scan."""
+    return [path for path in files if is_iac_file(path)]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 single-file IaC checker (checkov -f)
+# ---------------------------------------------------------------------------
+
+def run_checkov_file(path: str) -> tuple[int, str]:
+    """Run checkov on a single IaC file via uvx; return (returncode, stdout).
+
+    Uses list-form subprocess (never shell=True). Tool/IO failures degrade to
+    a clean (0, "") so a missing checkov never blocks a commit spuriously.
+    """
+    cmd = [
+        "uvx", "--from", "checkov", "checkov",
+        "-f", path, "--compact", "--quiet",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_CHECKOV_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0, ""
+    return proc.returncode, proc.stdout
+
+
+def check_iac(files: list[str]) -> int:
+    """Run checkov on each applicable IaC file; print only real findings.
+
+    Returns a non-zero exit code when checkov reports findings, 0 (silent)
+    when nothing is applicable or everything passes.
+    """
+    targets = iac_files(files)
+    if not targets:
+        return 0
+    failed = False
+    for path in targets:
+        code, output = run_checkov_file(path)
+        if code != 0 and output.strip():
+            sys.stdout.write(output if output.endswith("\n") else output + "\n")
+            failed = True
+    return 1 if failed else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI — internal plumbing for the shell git hooks
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the router CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--files", nargs="*", default=[])
+    parser.add_argument("--print-scanners", action="store_true")
+    parser.add_argument("--check-iac", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _existing_files(paths: list[str]) -> list[str]:
+    """Keep only paths that are real files on disk."""
+    return [path for path in paths if os.path.isfile(path)]
+
+
+def main(argv: list[str]) -> int:
+    """Route a change set to scanner names or run the Tier-1 IaC check."""
+    args = _parse_args(argv)
+    files = _existing_files(args.files)
+    if not files:
+        return 0
+    if args.check_iac:
+        return check_iac(files)
+    if args.print_scanners:
+        scanners = applicable_scanners(files)
+        if scanners:
+            sys.stdout.write(" ".join(sorted(scanners)) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/hooks/security_checks.py
+++ b/hooks/security_checks.py
@@ -45,7 +45,7 @@ def _run_checks(file_path: str, source: str, config: Config) -> list[Smell]:
     """Run applicable security checks on file contents."""
     lines = source.splitlines()
     smells = _collect_violations(file_path, source, lines, config)
-    return filter_suppressed(smells, lines, "security")
+    return filter_suppressed(smells, lines, "security", file_path)
 
 
 def _collect_violations(

--- a/hooks/smell_checks.py
+++ b/hooks/smell_checks.py
@@ -221,7 +221,7 @@ def check_file(file_path: str, config: Config | None = None) -> list[Smell]:
     smells.extend(check_file_length(file_path, lines, config))
     smells.extend(check_duplicate_blocks(file_path, lines, config))
     smells.extend(_run_lang_checks(ext, file_path, source))
-    return filter_suppressed(smells, lines, "smell")
+    return filter_suppressed(smells, lines, "smell", file_path)
 
 
 def format_violations(file_path: str, smells: list[Smell]) -> str:

--- a/hooks/smell_types.py
+++ b/hooks/smell_types.py
@@ -48,6 +48,32 @@ class Smell:
 
 
 # ---------------------------------------------------------------------------
+# Severity model for security findings (drives the on-write severity gate)
+# ---------------------------------------------------------------------------
+# Secrets are special-cased: they ALWAYS block and are never suppressible.
+SECURITY_SEVERITY = {
+    "secrets": "critical",
+    "B102": "high", "B105": "high", "B106": "high", "B602": "high",
+    "trojan_bidi": "high", "trojan_zero_width": "high",
+    "B301": "medium",
+    "B101": "low", "B110": "low",
+}
+_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+
+
+def severity_for(kind: str) -> str:
+    """Return the severity label for a security finding kind (default medium)."""
+    return SECURITY_SEVERITY.get(kind, "medium")
+
+
+def blocks_commit(smell: Smell) -> bool:
+    """Secrets always block; other security findings block only at HIGH+."""
+    if smell.kind == "secrets":
+        return True
+    return _SEVERITY_RANK.get(severity_for(smell.kind), 2) >= _SEVERITY_RANK["high"]
+
+
+# ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 

--- a/hooks/suppression.py
+++ b/hooks/suppression.py
@@ -10,8 +10,10 @@ No wildcards supported -- explicit check names required.
 
 from __future__ import annotations
 
+import os
 import re
 import sys
+from pathlib import Path
 
 from smell_types import Smell
 
@@ -68,15 +70,52 @@ def _warn_excessive(count: int, total_lines: int) -> None:
         )
 
 
+def _repo_root(start: str) -> str:
+    """Walk up from start to the nearest .git ancestor; fall back to start."""
+    current = os.path.abspath(start)
+    while True:
+        if os.path.isdir(os.path.join(current, ".git")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return os.path.abspath(start)
+        current = parent
+
+
+def _log_suppressions(
+    smells: list[Smell], namespace: str, file_path: str,
+) -> None:
+    """Append honored (non-secret) suppressions to the audit log, best-effort."""
+    root = _repo_root(os.path.dirname(os.path.abspath(file_path)))
+    log_path = Path(root) / ".quality-gate" / "suppressions.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as handle:
+            for smell in smells:
+                handle.write(f"{file_path}:{smell.line} {namespace}:{smell.kind}\n")
+    except OSError:
+        pass
+
+
 def filter_suppressed(
     smells: list[Smell], lines: list[str], namespace: str,
+    file_path: str | None = None,
 ) -> list[Smell]:
-    """Remove smells covered by inline suppression comments."""
+    """Remove smells covered by inline suppression comments.
+
+    Secrets are never suppressible. Every honored suppression is appended to
+    the audit log (.quality-gate/suppressions.log) when file_path is given.
+    """
     suppression_map = _build_suppression_map(lines)
     _warn_excessive(len(suppression_map), len(lines))
-    result: list[Smell] = []
+    kept: list[Smell] = []
+    honored: list[Smell] = []
     for smell in smells:
         active = suppression_map.get(smell.line, {})
-        if not _is_suppressed(smell, namespace, active):
-            result.append(smell)
-    return result
+        if smell.kind != "secrets" and _is_suppressed(smell, namespace, active):
+            honored.append(smell)
+        else:
+            kept.append(smell)
+    if honored and file_path:
+        _log_suppressions(honored, namespace, file_path)
+    return kept

--- a/hooks/tests/test_check_security.py
+++ b/hooks/tests/test_check_security.py
@@ -26,6 +26,21 @@ class TestCheckSecurityEntryPoint:
         output = json.loads(result.stdout)
         assert output["decision"] == "block"
 
+    def test_high_finding_blocks(self, tmp_py_file):
+        # exec() is B102 -> HIGH -> blocks.
+        path = tmp_py_file("exec('bad')\n")
+        result = _run_hook({"tool_input": {"file_path": path}})
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+    def test_medium_finding_warns_without_blocking(self, tmp_py_file):
+        # pickle.loads is B301 -> MEDIUM -> report on stderr, no block.
+        path = tmp_py_file("import pickle\npickle.loads(b'x')\n")
+        result = _run_hook({"tool_input": {"file_path": path}})
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+        assert "NOTICE" in result.stderr and "MEDIUM" in result.stderr
+
     def test_invalid_json_exits_cleanly(self):
         result = subprocess.run(
             [sys.executable, "hooks/check-security.py"],

--- a/hooks/tests/test_precommit_checks.py
+++ b/hooks/tests/test_precommit_checks.py
@@ -1,0 +1,67 @@
+"""Tests for hooks/precommit_checks.py — Tier 1 pre-commit logic."""
+
+from __future__ import annotations
+
+import precommit_checks
+
+# Assembled at runtime so this test file is not itself flagged as a secret.
+# Avoids false-positive words (example/test/dummy/...) so detection fires.
+_SECRET = "AKIA" + "IOSFODNN7ABCDQRST"
+
+
+def _write(tmp_path, name: str, content: str) -> str:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+class TestSecrets:
+    def test_staged_secret_blocks(self, tmp_path, capsys):
+        path = _write(tmp_path, "app.py", f"key = '{_SECRET}'\n")
+        assert precommit_checks.main([path]) == 1
+        assert "BLOCKED secret" in capsys.readouterr().err
+
+    def test_clean_source_passes(self, tmp_path, capsys):
+        path = _write(tmp_path, "app.py", "x = 1\nprint(x)\n")
+        assert precommit_checks.main([path]) == 0
+        assert capsys.readouterr().out == ""
+
+
+class TestApplicability:
+    def test_non_source_commit_is_silent(self, tmp_path, capsys):
+        path = _write(tmp_path, "README.md", "# Title\n")
+        assert precommit_checks.main([path]) == 0
+        out = capsys.readouterr()
+        assert out.out == "" and out.err == ""
+
+    def test_empty_file_list_exits_zero(self):
+        assert precommit_checks.main([]) == 0
+
+    def test_nonexistent_files_ignored(self):
+        assert precommit_checks.main(["/no/such/file.tf"]) == 0
+
+
+class TestIacGating:
+    def test_uvx_missing_warns_not_blocks(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(precommit_checks.shutil, "which", lambda _name: None)
+        path = _write(tmp_path, "main.tf", 'resource "x" "y" {}\n')
+        assert precommit_checks.main([path]) == 0
+        assert "uvx not found" in capsys.readouterr().err
+
+    def test_iac_findings_block(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(precommit_checks.shutil, "which", lambda _n: "/bin/uvx")
+        monkeypatch.setattr(precommit_checks, "check_iac", lambda _files: 1)
+        path = _write(tmp_path, "main.tf", 'resource "x" "y" {}\n')
+        assert precommit_checks.main([path]) == 1
+
+    def test_readme_does_not_invoke_checkov(self, tmp_path, monkeypatch):
+        called = {"n": 0}
+
+        def _boom(_files):
+            called["n"] += 1
+            return 0
+
+        monkeypatch.setattr(precommit_checks, "check_iac", _boom)
+        path = _write(tmp_path, "README.md", "# Title\n")
+        precommit_checks.main([path])
+        assert called["n"] == 0

--- a/hooks/tests/test_prepush_checks.py
+++ b/hooks/tests/test_prepush_checks.py
@@ -1,0 +1,91 @@
+"""Tests for hooks/prepush_checks.py — Tier 2 pre-push logic.
+
+ASH itself is never invoked here (it has a ~10s floor); _run_ash and
+changed_files are monkeypatched so the routing/gating logic is tested in
+isolation.
+"""
+
+from __future__ import annotations
+
+import prepush_checks
+
+
+class TestApplicabilityGate:
+    def test_no_changed_files_silent(self, monkeypatch, capsys):
+        monkeypatch.setattr(prepush_checks, "changed_files", lambda: [])
+        assert prepush_checks.main() == 0
+        out = capsys.readouterr()
+        assert out.out == "" and out.err == ""
+
+    def test_docs_only_push_does_not_invoke_ash(self, monkeypatch, capsys):
+        monkeypatch.setattr(prepush_checks, "changed_files", lambda: ["README.md"])
+
+        def _boom(*_a, **_k):
+            raise AssertionError("ASH must not run for a docs-only push")
+
+        monkeypatch.setattr(prepush_checks, "_run_ash", _boom)
+        assert prepush_checks.main() == 0
+        out = capsys.readouterr()
+        assert out.out == "" and out.err == ""
+
+    def test_code_change_invokes_ash(self, monkeypatch):
+        monkeypatch.setattr(prepush_checks, "changed_files", lambda: ["app.py"])
+        seen = {}
+
+        def _fake(_src, scanners):
+            seen["scanners"] = scanners
+            return 0, ""
+
+        monkeypatch.setattr(prepush_checks, "_run_ash", _fake)
+        monkeypatch.setattr(prepush_checks.shutil, "which", lambda _n: "/bin/uvx")
+        monkeypatch.setattr(prepush_checks, "_stage", lambda _f: "/tmp/x")
+        monkeypatch.setattr(prepush_checks.shutil, "rmtree", lambda *_a, **_k: None)
+        assert prepush_checks.main() == 0
+        assert "bandit" in seen["scanners"]
+
+
+class TestFailPolicy:
+    def _wire(self, monkeypatch, code, output=""):
+        monkeypatch.setattr(prepush_checks, "changed_files", lambda: ["main.tf"])
+        monkeypatch.setattr(prepush_checks, "_stage", lambda _f: "/tmp/x")
+        monkeypatch.setattr(prepush_checks.shutil, "rmtree", lambda *_a, **_k: None)
+        monkeypatch.setattr(prepush_checks, "_run_ash", lambda *_a: (code, output))
+
+    def test_findings_block(self, monkeypatch):
+        self._wire(monkeypatch, 2, "checkov: FAILED CKV_AWS_1\n")
+        monkeypatch.setattr(prepush_checks.shutil, "which", lambda _n: "/bin/uvx")
+        assert prepush_checks.main() == 1
+
+    def test_clean_passes(self, monkeypatch):
+        self._wire(monkeypatch, 0, "")
+        monkeypatch.setattr(prepush_checks.shutil, "which", lambda _n: "/bin/uvx")
+        assert prepush_checks.main() == 0
+
+    def test_uvx_missing_warns_not_blocks(self, monkeypatch, capsys):
+        monkeypatch.setattr(prepush_checks, "changed_files", lambda: ["main.tf"])
+        monkeypatch.setattr(prepush_checks.shutil, "which", lambda _n: None)
+        assert prepush_checks.main() == 0
+        assert "uvx not found" in capsys.readouterr().err
+
+
+class TestChangedFiles:
+    def test_falls_back_to_default_branch_when_no_push_ref(self, monkeypatch):
+        calls = []
+
+        def _fake_git(args):
+            calls.append(args)
+            if args[:3] == ["diff", "--name-only", "--diff-filter=ACM"]:
+                rev = args[3]
+                if rev == "@{push}":
+                    return None  # new branch: no upstream push ref
+                return "app.py\n"
+            if args[0] == "symbolic-ref":
+                return "refs/remotes/origin/main\n"
+            return None
+
+        monkeypatch.setattr(prepush_checks, "_run_git", _fake_git)
+        monkeypatch.setattr(prepush_checks.os.path, "isfile", lambda _p: True)
+        result = prepush_checks.changed_files()
+        assert result == ["app.py"]
+        # Confirms it never diffs the whole tree (always against a ref).
+        assert ["diff", "--name-only", "--diff-filter=ACM", "@{push}"] in calls

--- a/hooks/tests/test_scan_router.py
+++ b/hooks/tests/test_scan_router.py
@@ -1,0 +1,170 @@
+"""Tests for hooks/scan_router.py — applicability routing + IaC checks."""
+
+from __future__ import annotations
+
+import scan_router
+
+
+def _write(tmp_path, name: str, content: str) -> str:
+    """Create a file under tmp_path and return its string path."""
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+CFN_YAML = (
+    "AWSTemplateFormatVersion: '2010-09-09'\n"
+    "Resources:\n"
+    "  Bucket:\n"
+    "    Type: AWS::S3::Bucket\n"
+)
+CFN_YAML_NO_VERSION = (
+    "Resources:\n"
+    "  Bucket:\n"
+    "    Type: \"AWS::S3::Bucket\"\n"
+)
+GHA_WORKFLOW = (
+    "name: CI\n"
+    "on:\n"
+    "  push:\n"
+    "    branches: [main]\n"
+    "jobs:\n"
+    "  build:\n"
+    "    runs-on: ubuntu-latest\n"
+)
+K8S_MANIFEST = (
+    "apiVersion: apps/v1\n"
+    "kind: Deployment\n"
+    "metadata:\n"
+    "  name: web\n"
+)
+
+
+class TestCfnDetection:
+    def test_cfn_yaml_with_version(self, tmp_path):
+        path = _write(tmp_path, "template.yaml", CFN_YAML)
+        assert scan_router.is_cfn_template(path) is True
+
+    def test_cfn_yaml_without_version_uses_resource_type(self, tmp_path):
+        path = _write(tmp_path, "stack.yml", CFN_YAML_NO_VERSION)
+        assert scan_router.is_cfn_template(path) is True
+
+    def test_github_actions_workflow_is_not_cfn(self, tmp_path):
+        path = _write(tmp_path, "ci.yml", GHA_WORKFLOW)
+        assert scan_router.is_cfn_template(path) is False
+
+    def test_k8s_manifest_is_not_cfn(self, tmp_path):
+        path = _write(tmp_path, "deploy.yaml", K8S_MANIFEST)
+        assert scan_router.is_cfn_template(path) is False
+
+    def test_cfn_json(self, tmp_path):
+        body = '{"AWSTemplateFormatVersion": "2010-09-09", "Resources": {}}'
+        path = _write(tmp_path, "t.json", body)
+        assert scan_router.is_cfn_template(path) is True
+
+    def test_plain_json_is_not_cfn(self, tmp_path):
+        path = _write(tmp_path, "package.json", '{"name": "x"}')
+        assert scan_router.is_cfn_template(path) is False
+
+
+class TestK8sDetection:
+    def test_k8s_manifest_detected(self, tmp_path):
+        path = _write(tmp_path, "deploy.yaml", K8S_MANIFEST)
+        assert scan_router.is_k8s_manifest(path) is True
+
+    def test_gha_workflow_is_not_k8s(self, tmp_path):
+        path = _write(tmp_path, "ci.yml", GHA_WORKFLOW)
+        assert scan_router.is_k8s_manifest(path) is False
+
+
+class TestIacFile:
+    def test_terraform_is_iac(self, tmp_path):
+        path = _write(tmp_path, "main.tf", 'resource "x" "y" {}\n')
+        assert scan_router.is_iac_file(path) is True
+
+    def test_dockerfile_is_iac(self, tmp_path):
+        path = _write(tmp_path, "Dockerfile", "FROM alpine\n")
+        assert scan_router.is_iac_file(path) is True
+
+    def test_cfn_yaml_is_iac(self, tmp_path):
+        path = _write(tmp_path, "template.yaml", CFN_YAML)
+        assert scan_router.is_iac_file(path) is True
+
+    def test_gha_workflow_is_not_iac(self, tmp_path):
+        path = _write(tmp_path, "ci.yml", GHA_WORKFLOW)
+        assert scan_router.is_iac_file(path) is False
+
+    def test_readme_is_not_iac(self, tmp_path):
+        path = _write(tmp_path, "README.md", "# Hello\n")
+        assert scan_router.is_iac_file(path) is False
+
+
+class TestApplicableScanners:
+    def test_python_file_routes_to_bandit_semgrep_secrets(self, tmp_path):
+        path = _write(tmp_path, "app.py", "x = 1\n")
+        result = scan_router.applicable_scanners([path])
+        assert result == {"bandit", "semgrep", "detect-secrets"}
+
+    def test_terraform_routes_to_checkov_and_secrets(self, tmp_path):
+        path = _write(tmp_path, "main.tf", 'resource "x" "y" {}\n')
+        result = scan_router.applicable_scanners([path])
+        assert "checkov" in result
+        assert "cfn-nag" not in result
+
+    def test_cfn_routes_to_checkov_and_cfn_nag(self, tmp_path):
+        path = _write(tmp_path, "template.yaml", CFN_YAML)
+        result = scan_router.applicable_scanners([path])
+        assert {"checkov", "cfn-nag"} <= result
+
+    def test_gha_workflow_does_not_route_to_cfn_nag(self, tmp_path):
+        path = _write(tmp_path, "ci.yml", GHA_WORKFLOW)
+        result = scan_router.applicable_scanners([path])
+        assert "cfn-nag" not in result
+        assert "checkov" not in result
+
+    def test_readme_routes_only_to_secrets(self, tmp_path):
+        path = _write(tmp_path, "README.md", "# Hello\n")
+        result = scan_router.applicable_scanners([path])
+        assert result == {"detect-secrets"}
+
+    def test_lockfile_routes_to_npm_audit_and_grype(self, tmp_path):
+        path = _write(tmp_path, "package-lock.json", '{"name": "x"}')
+        result = scan_router.applicable_scanners([path])
+        assert {"npm-audit", "grype"} <= result
+
+    def test_editing_source_does_not_trigger_grype(self, tmp_path):
+        path = _write(tmp_path, "app.py", "x = 1\n")
+        assert "grype" not in scan_router.applicable_scanners([path])
+
+    def test_empty_change_set_yields_no_scanners(self):
+        assert scan_router.applicable_scanners([]) == set()
+
+    def test_binary_asset_is_not_text(self, tmp_path):
+        path = _write(tmp_path, "logo.png", "not really a png")
+        assert "detect-secrets" not in scan_router.applicable_scanners([path])
+
+
+class TestMainCli:
+    def test_no_files_exits_silently(self, capsys):
+        assert scan_router.main(["--print-scanners"]) == 0
+        assert capsys.readouterr().out == ""
+
+    def test_nonexistent_files_exit_silently(self, capsys):
+        assert scan_router.main(["--print-scanners", "--files", "/no/such"]) == 0
+        assert capsys.readouterr().out == ""
+
+    def test_print_scanners_for_python(self, tmp_path, capsys):
+        path = _write(tmp_path, "app.py", "x = 1\n")
+        scan_router.main(["--print-scanners", "--files", path])
+        out = capsys.readouterr().out.split()
+        assert "bandit" in out
+
+    def test_readme_prints_only_secrets(self, tmp_path, capsys):
+        path = _write(tmp_path, "README.md", "# Hi\n")
+        scan_router.main(["--print-scanners", "--files", path])
+        assert capsys.readouterr().out.strip() == "detect-secrets"
+
+    def test_check_iac_silent_when_no_iac(self, tmp_path, capsys):
+        path = _write(tmp_path, "README.md", "# Hi\n")
+        assert scan_router.main(["--check-iac", "--files", path]) == 0
+        assert capsys.readouterr().out == ""

--- a/hooks/tests/test_suppression.py
+++ b/hooks/tests/test_suppression.py
@@ -1,5 +1,7 @@
 """Tests for suppression module."""
 
+from pathlib import Path
+
 from smell_types import Smell
 from suppression import filter_suppressed
 
@@ -46,8 +48,43 @@ class TestFilterSuppressed:
         result = filter_suppressed(smells, lines, "smell")
         assert result == []
 
-    def test_security_namespace(self):
+    def test_security_namespace_suppresses_non_secret(self):
+        smells = [_smell("B101", 2)]
+        lines = ["# security: ignore[B101]", "assert x"]
+        result = filter_suppressed(smells, lines, "security")
+        assert result == []
+
+    def test_secrets_are_never_suppressible(self):
+        # Secrets must NOT be suppressible even with a matching ignore.
         smells = [_smell("secrets", 2)]
         lines = ["# security: ignore[secrets]", "key = 'abc'"]
         result = filter_suppressed(smells, lines, "security")
+        assert result == smells
+
+
+class TestSuppressionAuditLog:
+    def test_honored_suppression_is_logged(self, tmp_path):
+        target = tmp_path / "mod.py"
+        target.write_text("# smell: ignore[complexity]\ndef f(): pass\n")
+        smells = [_smell("complexity", 2)]
+        lines = ["# smell: ignore[complexity]", "def f(): pass"]
+        result = filter_suppressed(smells, lines, "smell", str(target))
         assert result == []
+        log = tmp_path / ".quality-gate" / "suppressions.log"
+        assert log.exists()
+        assert f"{target}:2 smell:complexity" in log.read_text()
+
+    def test_suppressed_secret_is_not_logged(self, tmp_path):
+        target = tmp_path / "mod.py"
+        target.write_text("key = 'abc'  # security: ignore[secrets]\n")
+        smells = [_smell("secrets", 1)]
+        lines = ["key = 'abc'  # security: ignore[secrets]"]
+        result = filter_suppressed(smells, lines, "security", str(target))
+        # Secret kept (never suppressed) -> nothing honored -> no log file.
+        assert result == smells
+        assert not (tmp_path / ".quality-gate" / "suppressions.log").exists()
+
+    def test_no_file_path_skips_logging(self):
+        smells = [_smell("complexity", 1)]
+        lines = ["x = 1  # smell: ignore[complexity]"]
+        assert filter_suppressed(smells, lines, "smell") == []

--- a/hooks/tests/test_wire_settings.py
+++ b/hooks/tests/test_wire_settings.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/wire-settings.py — idempotent, additive settings merge."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "wire-settings.py",
+)
+
+_SOURCE = {
+    "hooks": {
+        "PostToolUse": [
+            {"matcher": "Write|Edit", "hooks": [
+                {"type": "command", "command": "python3 ~/.claude/hooks/check-security.py"},
+            ]},
+        ],
+    }
+}
+
+
+def _write(path, data):
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle)
+
+
+def _run(source_path, target_path):
+    return subprocess.run(
+        [sys.executable, _SCRIPT, "--source", source_path, "--target", target_path],
+        capture_output=True, text=True, timeout=10,
+    )
+
+
+def _post_commands(settings):
+    groups = settings["hooks"]["PostToolUse"]
+    return [h["command"] for g in groups for h in g["hooks"]]
+
+
+class TestWireSettings:
+    def test_merges_into_empty_target(self, tmp_path):
+        src = tmp_path / "src.json"; _write(src, _SOURCE)
+        tgt = tmp_path / "settings.json"
+        assert _run(str(src), str(tgt)).returncode == 0
+        out = json.loads(tgt.read_text())
+        assert "check-security.py" in _post_commands(out)[0]
+
+    def test_idempotent_no_duplicates(self, tmp_path):
+        src = tmp_path / "src.json"; _write(src, _SOURCE)
+        tgt = tmp_path / "settings.json"
+        _run(str(src), str(tgt))
+        _run(str(src), str(tgt))  # second run must be a no-op
+        out = json.loads(tgt.read_text())
+        assert len(_post_commands(out)) == 1
+
+    def test_preserves_existing_unrelated_hooks(self, tmp_path):
+        existing = {"hooks": {"UserPromptSubmit": [
+            {"matcher": "", "hooks": [{"type": "command", "command": "echo keep-me"}]},
+        ]}}
+        src = tmp_path / "src.json"; _write(src, _SOURCE)
+        tgt = tmp_path / "settings.json"; _write(tgt, existing)
+        _run(str(src), str(tgt))
+        out = json.loads(tgt.read_text())
+        ups = out["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+        assert ups == "echo keep-me"  # untouched
+        assert "check-security.py" in _post_commands(out)[0]  # ours added
+
+    def test_appends_command_to_existing_matcher(self, tmp_path):
+        existing = {"hooks": {"PostToolUse": [
+            {"matcher": "Write|Edit", "hooks": [
+                {"type": "command", "command": "python3 ~/.claude/hooks/other.py"},
+            ]},
+        ]}}
+        src = tmp_path / "src.json"; _write(src, _SOURCE)
+        tgt = tmp_path / "settings.json"; _write(tgt, existing)
+        _run(str(src), str(tgt))
+        cmds = _post_commands(json.loads(tgt.read_text()))
+        assert any("other.py" in c for c in cmds)
+        assert any("check-security.py" in c for c in cmds)

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# install-git-hooks.sh — install chained git hooks for the tiered scanner spine.
+#
+# Installs thin shims at .git/hooks/<hook> that run this repo's tracked logic
+# (hooks/git/<hook>) and then CHAIN any pre-existing hook (e.g. the beads
+# pre-commit), which is preserved as .git/hooks/<hook>.chained. Git's default
+# hooks directory is retained — no core.hooksPath override — so existing hooks
+# keep working untouched.
+#
+# Usage: bash scripts/install-git-hooks.sh [--uninstall]
+# Idempotent and safe to run multiple times.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$REPO_DIR/hooks/git/shim.template"
+MARKER="claude-code-managed chained hook"
+UNINSTALL=false
+[ "${1:-}" = "--uninstall" ] && UNINSTALL=true
+
+# Resolve the absolute hooks directory for this repo (worktree-safe).
+GIT_DIR="$(git -C "$REPO_DIR" rev-parse --git-dir 2>/dev/null || true)"
+if [ -z "$GIT_DIR" ]; then
+    echo "Not a git repository; skipping git-hook install."
+    exit 0
+fi
+case "$GIT_DIR" in
+    /*) ;;
+    *) GIT_DIR="$REPO_DIR/$GIT_DIR" ;;
+esac
+HOOKS_DIR="$GIT_DIR/hooks"
+mkdir -p "$HOOKS_DIR"
+
+is_managed() { grep -q "$MARKER" "$1" 2>/dev/null; }
+
+uninstall_one() {
+    local hook="$1" target="$HOOKS_DIR/$1"
+    if [ -f "$target" ] && is_managed "$target"; then
+        rm -f "$target"
+        if [ -f "$target.chained" ]; then
+            mv "$target.chained" "$target"
+            echo "  removed $hook shim (restored chained hook)"
+        else
+            echo "  removed $hook shim"
+        fi
+    fi
+}
+
+install_one() {
+    local hook="$1" target="$HOOKS_DIR/$1"
+    # Preserve a pre-existing, non-managed hook by chaining it.
+    if [ -f "$target" ] && ! is_managed "$target"; then
+        mv "$target" "$target.chained"
+        chmod +x "$target.chained" 2>/dev/null || true
+        echo "  preserved existing $hook -> $hook.chained"
+    fi
+    sed "s/HOOKNAME/$hook/g" "$TEMPLATE" > "$target"
+    chmod +x "$target"
+    echo "  installed $hook (chained)"
+}
+
+echo "Installing chained git hooks into $HOOKS_DIR"
+for hook in pre-commit pre-push; do
+    [ -f "$REPO_DIR/hooks/git/$hook" ] || continue
+    if $UNINSTALL; then
+        uninstall_one "$hook"
+    else
+        install_one "$hook"
+    fi
+done
+echo "Done."

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -132,6 +132,12 @@ if $UNINSTALL; then
         fi
     fi
 
+    if ! $DRY_RUN && [ -f "$SCRIPT_DIR/install-git-hooks.sh" ]; then
+        echo ""
+        echo "Removing chained git hooks..."
+        bash "$SCRIPT_DIR/install-git-hooks.sh" --uninstall || true
+    fi
+
     echo ""
     echo "Done. Removed $installed, skipped $skipped."
     exit 0
@@ -212,6 +218,16 @@ EOF
         log_action "added claude wrapper to .zshrc"
         installed=$((installed + 1))
     fi
+fi
+
+echo ""
+echo "Installing chained git hooks (pre-commit / pre-push)..."
+if $DRY_RUN; then
+    log_dry "install chained git hooks via install-git-hooks.sh"
+elif [ -f "$SCRIPT_DIR/install-git-hooks.sh" ]; then
+    bash "$SCRIPT_DIR/install-git-hooks.sh" || echo "  WARN: git-hook install reported an issue"
+else
+    echo "  WARN: install-git-hooks.sh not found; skipping"
 fi
 
 echo ""

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -17,17 +17,23 @@ TARGET_HOOKS_DIR="$HOME/.claude/hooks"
 ZSHRC="$HOME/.zshrc"
 DRY_RUN=false
 UNINSTALL=false
+WIRE_SETTINGS=false
 
 for arg in "$@"; do
     case "$arg" in
         --dry-run) DRY_RUN=true ;;
         --uninstall) UNINSTALL=true ;;
+        --wire-settings) WIRE_SETTINGS=true ;;
         --help|-h)
-            echo "Usage: bash scripts/setup-hooks.sh [--dry-run] [--uninstall]"
+            echo "Usage: bash scripts/setup-hooks.sh [--dry-run] [--uninstall] [--wire-settings]"
             echo ""
             echo "Options:"
-            echo "  --dry-run    Show what would be done without making changes"
-            echo "  --uninstall  Remove installed symlinks and .zshrc wrapper"
+            echo "  --dry-run        Show what would be done without making changes"
+            echo "  --uninstall      Remove installed symlinks and .zshrc wrapper"
+            echo "  --wire-settings  Also merge the PostToolUse/PreToolUse hook config"
+            echo "                   into ~/.claude/settings.json (idempotent, additive)."
+            echo "                   Off by default so your global settings are never"
+            echo "                   edited unless you ask."
             exit 0
             ;;
         *)
@@ -228,6 +234,23 @@ elif [ -f "$SCRIPT_DIR/install-git-hooks.sh" ]; then
     bash "$SCRIPT_DIR/install-git-hooks.sh" || echo "  WARN: git-hook install reported an issue"
 else
     echo "  WARN: install-git-hooks.sh not found; skipping"
+fi
+
+echo ""
+if $WIRE_SETTINGS; then
+    echo "Wiring hook config into ~/.claude/settings.json..."
+    if $DRY_RUN; then
+        log_dry "merge $SOURCE_HOOKS_DIR/settings.example.json into ~/.claude/settings.json"
+    else
+        python3 "$SCRIPT_DIR/wire-settings.py" \
+            --source "$SOURCE_HOOKS_DIR/settings.example.json" \
+            --target "$HOME/.claude/settings.json" \
+            || echo "  WARN: settings wiring reported an issue"
+    fi
+else
+    echo "Tier 0 (PostToolUse) activation: hook config NOT wired into settings.json."
+    echo "  Re-run with --wire-settings to merge it automatically (idempotent),"
+    echo "  or merge $SOURCE_HOOKS_DIR/settings.example.json manually."
 fi
 
 echo ""

--- a/scripts/wire-settings.py
+++ b/scripts/wire-settings.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Idempotently merge the Claude Code hook config into a settings.json.
+
+Opt-in: invoked only by ``setup-hooks.sh --wire-settings``. Adds the
+PostToolUse / PreToolUse / Stop / UserPromptSubmit hook commands from
+hooks/settings.example.json into the target settings.json WITHOUT removing or
+overwriting any existing hooks (matched by command string). Safe to run
+repeatedly — re-running is a no-op once wired.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+def _load(path: str) -> dict:
+    """Load a JSON file, returning {} when missing or unparseable."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _commands(group: dict) -> set:
+    """Return the set of command strings already present in a hook group."""
+    return {hook.get("command") for hook in group.get("hooks", [])}
+
+
+def _merge_group(target_groups: list, src_group: dict) -> None:
+    """Add a source group's commands into a matching target group, or append."""
+    matcher = src_group.get("matcher", "")
+    for group in target_groups:
+        if group.get("matcher", "") == matcher:
+            have = _commands(group)
+            for hook in src_group.get("hooks", []):
+                if hook.get("command") not in have:
+                    group.setdefault("hooks", []).append(hook)
+            return
+    target_groups.append(src_group)
+
+
+def merge(target: dict, source: dict) -> dict:
+    """Merge source hooks into target additively; mutate and return target."""
+    target_hooks = target.setdefault("hooks", {})
+    for event, groups in source.get("hooks", {}).items():
+        dest = target_hooks.setdefault(event, [])
+        for group in groups:
+            _merge_group(dest, group)
+    return target
+
+
+def _write(path: str, data: dict) -> None:
+    """Write JSON to path, creating parent directories as needed."""
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Merge --source hook config into --target settings.json (idempotent)."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    merged = merge(_load(args.target), _load(args.source))
+    if args.dry_run:
+        print(json.dumps(merged, indent=2))
+        return 0
+    _write(args.target, merged)
+    print(f"wired hook config into {args.target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/xact.sh
+++ b/scripts/xact.sh
@@ -129,12 +129,17 @@ install_dependencies() {
                 install_failed=true
             fi
         elif [[ "$OSTYPE" == "linux"* ]]; then
-            if curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash; then
+            # Download the installer to a temp file first (no curl|bash) so it
+            # can be inspected/verified before execution.
+            act_installer="$(mktemp)"
+            if curl -fsSL https://raw.githubusercontent.com/nektos/act/master/install.sh -o "$act_installer" \
+                && sudo bash "$act_installer"; then
                 echo "✓ nektos/act installed successfully"
             else
                 echo "✗ Failed to install nektos/act"
                 install_failed=true
             fi
+            rm -f "$act_installer"
         else
             echo "✗ Unsupported platform: $OSTYPE"
             install_failed=true

--- a/slash-commands/active/xsecurity.md
+++ b/slash-commands/active/xsecurity.md
@@ -1,20 +1,27 @@
 ---
-description: Run security scans with maturity-aware checks and centralized-rules integration
-tags: [security, vulnerabilities, scanning, owasp, secrets, dependencies]
+description: Run security scans via AWS Automated Security Helper (ASH) with maturity-aware thresholds and centralized-rules integration
+tags: [security, vulnerabilities, scanning, ash, secrets, dependencies, sast]
 ---
 
 # Security Analysis
 
-Perform comprehensive security scanning aligned to centralized-rules security principles. No parameters needed for basic usage.
+Run comprehensive security scanning through **AWS Automated Security Helper
+(ASH, pinned v3.2.6)**, aligned to centralized-rules security principles. ASH
+bundles Bandit, Semgrep, detect-secrets, Checkov, cfn-nag, Grype, and npm-audit
+under one CLI and emits unified SARIF/JSON. No parameters needed for basic usage.
+
+This command **shells out to ASH** (deterministic and CI-portable); it does
+**not** depend on the ASH MCP server. The agent-mediated MCP path lives in the
+security-auditor subagent — see the role split below.
 
 ## Usage Examples
 
-**Basic usage (runs all security checks):**
+**Basic usage (full ASH scan, all applicable scanners):**
 ```
 /xsecurity
 ```
 
-**Quick secret scan:**
+**Quick secret scan (standalone, no ASH/uvx required):**
 ```
 /xsecurity secrets
 ```
@@ -42,18 +49,34 @@ Perform comprehensive security scanning aligned to centralized-rules security pr
 
 ## Implementation
 
+ASH is pinned to an **immutable commit SHA** (not the mutable `v3.2.6` tag) so
+runs are reproducible. This is the single recorded pin, kept consistent with
+`.ash/ash.yaml`, `docs/ash-integration.md`, and the pre-push/CI jobs:
+
+```
+ASH_REF=1dca6b3d10ff274115a159d869bdff8b98624b62   # == tag v3.2.6
+ASH="uvx --from git+https://github.com/awslabs/automated-security-helper@${ASH_REF} ash"
+```
+
 If $ARGUMENTS contains "help" or "--help":
-Display this usage information and exit.
+Display this usage information, including the ASH scanner bundle, the three-role
+split (this command = on-demand shell-out; hooks = fast deterministic gate;
+security-auditor subagent = agent-mediated MCP), and exit.
 
-### Step 1: Detect Project Context
+### Step 1: Detect Project Context and ASH Availability
 
-Detect project type and available security tools:
-!ls -la | grep -E "(package.json|requirements.txt|go.mod|Gemfile|pom.xml|composer.json|Cargo.toml)"
-!find . -name ".env*" -not -name ".env.example" | head -5
+Detect project type and confirm ASH can run (uvx present). If ASH is
+unavailable, fall back to the lightweight standalone checks (secrets mode) and
+tell the user how to enable the full scan.
+
+!ls -la | grep -E "(package.json|requirements.txt|go.mod|Gemfile|pom.xml|composer.json|Cargo.toml|\.tf$)" 2>/dev/null
+!command -v uvx >/dev/null 2>&1 && echo "uvx available: full ASH scan enabled" || echo "uvx NOT found: install uv (https://docs.astral.sh/uv/) for full ASH scans; secrets mode still works"
+!find . -name ".env" -not -name ".env.example" -not -path "*/node_modules/*" 2>/dev/null | head -5
 
 ### Step 2: Apply Maturity-Aware Requirements
 
-Per centralized-rules/base/security-principles, requirements vary by maturity:
+Per centralized-rules/base/security-principles, requirements vary by maturity.
+These thresholds govern what **blocks** vs what is **reported**:
 
 | Practice | MVP/POC | Pre-Production | Production |
 |----------|---------|----------------|------------|
@@ -68,83 +91,97 @@ Per centralized-rules/base/security-principles, requirements vary by maturity:
 | Dependency scanning | Optional | Required | Required |
 | Secret scanning | Optional | Required | Required |
 
+**Severity gate by maturity** (applied to ASH findings):
+- **MVP/POC**: block only on CRITICAL and any secret; report everything else.
+- **Pre-Production**: block on HIGH+ and any secret; report MEDIUM/LOW.
+- **Production**: block on MEDIUM+ and any secret; report LOW/INFO.
+
+Secrets always block at every maturity level.
+
 ### Step 3: Execute Based on Mode
 
-**Mode 1: Comprehensive Scan (no arguments or "all")**
+**Mode 1: Comprehensive ASH Scan (no arguments or "all")**
 If $ARGUMENTS is empty or contains "all":
 
-Run complete security analysis covering all centralized-rules principles:
+Run ASH in local mode. `--mode local` uses host scanners via UV tool isolation
+(no container/Docker needed) and honors `.ash/ash.yaml` (severity_threshold
+MEDIUM, cdk-nag disabled). Results land in `.ash/ash_output/`.
 
-1. **Secret Detection**: Scan for exposed credentials and API keys
-!git grep -i -E "(api[_-]?key|secret[_-]?key|password|token|credential|private[_-]?key)" --no-index 2>/dev/null | grep -v -E "(test|spec|mock|example|\.md)" | head -15 || echo "No secrets found in code"
-!find . -name ".env" -not -name ".env.example" -exec echo "WARNING: .env file found: {}" \; 2>/dev/null
+!ASH_REF=1dca6b3d10ff274115a159d869bdff8b98624b62; uvx --from git+https://github.com/awslabs/automated-security-helper@${ASH_REF} ash --mode local 2>&1 | tail -20 || echo "ASH run finished with findings or an error; parsing results below"
 
-2. **Dependency Vulnerabilities**: Check for known CVEs
-!pip-audit 2>/dev/null || npm audit --audit-level=high 2>/dev/null || echo "Install pip-audit or use npm for dependency checks"
+Then parse `.ash/ash_output/ash_aggregated_results.json` and present results.
+Read these keys (schema: AshAggregatedResults at the pinned ref):
 
-3. **Dangerous Code Patterns**: Look for injection risks
-!grep -r -n -E "(eval\(|exec\(|system\(|__import__\(|subprocess\.call\(.*shell=True)" . --include="*.py" 2>/dev/null | head -10
-!grep -r -n -E "(innerHTML|dangerouslySetInnerHTML|document\.write)" . --include="*.js" --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+- **Per-finding detail** — `sarif.runs[].results[]`: each has `ruleId`,
+  `level`, `message.text`, `properties` (scanner name + severity), and
+  `locations[0].physicalLocation.artifactLocation.uri` +
+  `...region.startLine`.
+- **Per-scanner counts** — `scanner_results[<scanner>]` carry a
+  `ScannerSeverityCount` (`critical/high/medium/low/info/suppressed`).
+- **Severity values** are the ASH `Severity` enum:
+  `critical, high, medium, low, info, none, unknown`.
 
-4. **SQL Injection**: Check for string-interpolated queries
-!grep -r -n -E "(f\".*SELECT|f\".*INSERT|f\".*UPDATE|f\".*DELETE|\.format\(.*SELECT)" . --include="*.py" 2>/dev/null | head -10
-!grep -r -n -E "(\`.*SELECT.*\$\{|\`.*INSERT.*\$\{)" . --include="*.js" --include="*.ts" 2>/dev/null | head -10
+!test -f .ash/ash_output/ash_aggregated_results.json && echo "FOUND results" || echo "No aggregated results file — ASH may not have produced output; report the run output above"
 
-5. **Configuration Review**: Check for insecure settings
-!grep -r -n -E "(DEBUG\s*=\s*True|CORS_ALLOW_ALL|verify\s*=\s*False|SSL_VERIFY.*false)" . --include="*.py" --include="*.js" --include="*.ts" --include="*.yml" --include="*.yaml" 2>/dev/null | head -10
+Present a **severity-grouped summary table** (count per severity), then list the
+actionable findings (CRITICAL → HIGH → MEDIUM → LOW) with
+`scanner · ruleId · file:line · message`. Apply the Step 2 severity gate for the
+detected maturity to decide which findings **block** vs are **reported only**.
+Note any suppressed findings (from `.ash/ash.yaml` suppressions) separately.
 
-**Mode 2: Secret Scan Only (argument: "secrets")**
+**Mode 2: Secret Scan Only (argument: "secrets") — standalone, no ASH required**
 If $ARGUMENTS contains "secrets":
 
-Focus on credential exposure per centralized-rules principle #1 (Never Hardcode Secrets):
-!git grep -i -E "(api[_-]?key|secret|password|token|credential|private[_-]?key|aws_access)" --no-index 2>/dev/null | grep -v -E "(test|spec|mock|example|\.md|\.lock)" | head -20
-!git log -p --all -S"api_key" --pickaxe-all 2>/dev/null | grep -E "^\+.*api_key" | head -5 || echo "No secrets in git history"
-!find . -name "*.pem" -o -name "*.key" -o -name "*.p12" 2>/dev/null | head -5
+A fast, dependency-free credential sweep that works even without uvx/ASH. (The
+full ASH scan also runs detect-secrets; this mode is the standalone equivalent.)
+Per centralized-rules principle #1 (Never Hardcode Secrets):
 
-Verify proper secret management:
-- Environment variables used for secrets
-- `.env` files are gitignored
-- No secrets in committed configuration files
+!git grep -i -E "(api[_-]?key|secret|password|token|credential|private[_-]?key|aws_access)" -- ':!*.md' ':!*.lock' 2>/dev/null | grep -v -E "(test|spec|mock|example|placeholder)" | head -20 || echo "No obvious secrets in tracked files"
+!git log -p --all -S"api_key" --pickaxe-all 2>/dev/null | grep -E "^\+.*api_key" | head -5 || echo "No secrets in git history"
+!find . -name "*.pem" -o -name "*.key" -o -name "*.p12" 2>/dev/null | grep -v node_modules | head -5
+
+Verify: environment variables used for secrets; `.env` gitignored; no secrets in
+committed config. Secrets always block regardless of maturity.
 
 **Mode 3: Dependency Check (argument: "deps")**
 If $ARGUMENTS contains "deps":
 
-Per centralized-rules principle #7 (Dependency Management):
-!pip-audit --format=columns 2>/dev/null || npm audit 2>/dev/null || echo "Checking dependencies..."
-!pip list --outdated 2>/dev/null | head -15 || npm outdated 2>/dev/null | head -15
+ASH covers dependencies via Grype (SCA) and npm-audit. Run the full scan and
+filter to dependency findings, or use the native tools directly:
 
-Check:
-- Known CVEs in dependencies
-- Outdated packages with security patches
-- Unused dependencies (reducing exposure)
-- Lock file integrity
+!ASH_REF=1dca6b3d10ff274115a159d869bdff8b98624b62; uvx --from git+https://github.com/awslabs/automated-security-helper@${ASH_REF} ash --mode local 2>&1 | tail -10 || pip-audit 2>/dev/null || npm audit 2>/dev/null || echo "Install uv for ASH, or pip-audit/npm for native dependency checks"
+
+Report known CVEs, outdated packages with security patches, and lock-file
+integrity from `scanner_results.grype` / `scanner_results["npm-audit"]`.
 
 **Mode 4: OWASP Top 10 Review (argument: "owasp")**
 If $ARGUMENTS contains "owasp":
 
-Review code against OWASP Top 10 categories:
+Map ASH's Bandit/Semgrep/Checkov findings to OWASP Top 10 categories, then review
+code for gaps the scanners cannot see:
 
-1. **Injection** (A03): Check parameterized queries, input sanitization
-2. **Broken Auth** (A07): Check password hashing (bcrypt/Argon2), session management
-3. **Sensitive Data Exposure** (A02): Check encryption at rest/transit, error messages
-4. **XSS** (A03): Check output encoding, CSP headers
-5. **CSRF** (A01): Check CSRF tokens, SameSite cookies
-6. **Security Misconfiguration** (A05): Check default credentials, debug mode
-7. **Vulnerable Components** (A06): Check dependency versions
+1. **Injection** (A03): parameterized queries, input sanitization
+2. **Broken Auth** (A07): password hashing (bcrypt/Argon2), session management
+3. **Sensitive Data Exposure** (A02): encryption at rest/transit, error messages
+4. **XSS** (A03): output encoding, CSP headers
+5. **CSRF** (A01): CSRF tokens, SameSite cookies
+6. **Security Misconfiguration** (A05): default credentials, debug mode
+7. **Vulnerable Components** (A06): dependency versions (Grype/npm-audit)
 
 For each category, report: found/not-found/not-applicable with file locations.
 
 **Mode 5: Security Checklist Audit (argument: "checklist")**
 If $ARGUMENTS contains "checklist":
 
-Run the complete centralized-rules secure development checklist:
+Run the complete centralized-rules secure development checklist, using ASH
+findings as evidence where applicable:
 - [ ] No hardcoded secrets or credentials
 - [ ] All user input validated and sanitized
 - [ ] Authentication and authorization implemented
 - [ ] Sensitive data encrypted (at rest and in transit)
 - [ ] HTTPS used for all communication
 - [ ] Error messages don't leak internal details
-- [ ] Dependencies scanned for vulnerabilities
+- [ ] Dependencies scanned for vulnerabilities (ASH: Grype/npm-audit)
 - [ ] Security tests passing
 - [ ] Security events logged (without secrets in logs)
 - [ ] Principle of least privilege applied
@@ -155,16 +192,19 @@ Report pass/fail for each item with file locations for any issues.
 
 ## Security Analysis Results
 
-Categorize findings by severity (per centralized-rules incident response levels):
-- **Critical**: High-risk vulnerability or data breach potential (fix immediately)
-- **High**: Serious vulnerability (fix within days)
-- **Medium**: Important issue (fix in next release)
-- **Low**: Minor issue (fix when convenient)
+Categorize findings by the ASH severity enum (per centralized-rules incident
+response levels):
+- **Critical**: high-risk vulnerability or data-breach potential (fix immediately)
+- **High**: serious vulnerability (fix within days)
+- **Medium**: important issue (fix in next release)
+- **Low / Info**: minor issue (fix when convenient)
 
 Provide:
-1. **Security Status**: Overall posture assessment
-2. **Critical Issues**: Problems requiring immediate attention with file:line locations
-3. **Recommended Actions**: Priority-ordered fix list with specific remediation
-4. **Prevention Tips**: How to avoid similar issues
+1. **Security Status**: overall posture and the severity-grouped summary table
+2. **Blocking Issues**: findings that exceed the maturity severity gate, with
+   `scanner · ruleId · file:line`
+3. **Reported (non-blocking) Issues**: findings below the gate
+4. **Recommended Actions**: priority-ordered fix list with concrete remediation
+5. **Suppressed**: findings excluded via `.ash/ash.yaml`, shown for transparency
 
 Keep output focused on actionable findings with concrete remediation steps.


### PR DESCRIPTION
Integrates AWS Automated Security Helper (ASH, pinned to commit `1dca6b3` == tag v3.2.6) as the scanner orchestration layer across four latency tiers. Additive to the existing inline Python hooks.

## This PR is the merge gate, not a review gate
This repo publishes via **manual `workflow_dispatch`** (`npm-publish-manual.yml`), **not** semantic-release. This PR exists purely so the **Tier 3 CI job (`ash.yml`) runs via the `pull_request` trigger and gates the merge**. No human review is required — **merge as soon as CI is green**. The in-loop verification (tiered hooks + this CI gate) is what makes a review gate redundant.

## Tiers
| Tier | Trigger | Budget | What runs |
|------|---------|--------|-----------|
| 0 on-write | PostToolUse | <300ms | inline Python smell + secret checks (severity-gated) |
| 1 pre-commit | `git commit` | <5s | secrets + `checkov` on staged IaC |
| 2 pre-push | `git push` | <30s | ASH precommit (Python-only), push-range scoped |
| 3 CI | PR / push main | minutes | ASH container, full tree, SARIF + SBOM — **un-bypassable** |

## Commits (one per task)
- `e992be5` feat(ash): config + Tier-1 IaC checker + applicability router [bd-a31]
- `f607159` feat(xsecurity): drive scans through ASH local mode [bd-2oo]
- `0e6981f` feat(hooks): Tier-1 pre-commit spine + security severity gate [bd-wka]
- `15b3408` ci(ash): Tier-2 pre-push + Tier-3 CI gate [bd-bnt]
- `f2af7f8` docs(hooks): four-tier model in README [bd-umd]

## Hardening
cdk-nag disabled (cited CfnInclude collision); ASH + all GitHub Actions pinned by SHA; CI job is `contents: read`, no secrets, egress-controlled (harden-runner), SBOM artifact. cdk-nag off, cfn-nag + checkov on for CloudFormation.

## Benchmarks (recorded in `docs/ash-integration.md`)
checkov `-f` ~1.55s → Tier 1 (not Tier 0). ASH precommit: cold 82s (one-time), warm ~10s floor, zero-input 9.7s → wrapper-level applicability gating. Container number from this CI run.

## Verification
155 pytest (fully local) + repo shell/JS suite green; isolated end-to-end runs confirm chaining preserves beads, blocks staged secrets, idempotent install/uninstall, and a real ASH wrapper run (10.6s, findings).

## Scope notes
T3 (subagent ASH MCP) intentionally skipped (least-automatic, largest attack surface). T7 (opt-in npm distribution of the spine) filed as a follow-up — not in this PR. Pre-existing unrelated drift (`hooks/check-complexity.py`, `statusline.sh`) deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ASH-based security scanning across four tiers (on-write, pre-commit, pre-push, CI) with applicability-aware scanner routing, CI artifact uploads, and installer/wire-settings for local integration.
  * Git hook installer and chained-hook shims for pre-commit/pre-push activation.
  * Tiered hooks that scope fast checks locally and stage push-range files for pre-push scans.
  * Audit logging for honored suppressions; secrets are never suppressible.

* **Behavior Changes**
  * Severity gates: secrets + HIGH findings block; MEDIUM and below are reported without blocking.

* **Documentation**
  * Expanded ASH integration, four-tier model, and command usage.

* **Tests**
  * Added comprehensive tests for hooks, routing, suppression, and gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->